### PR TITLE
Added notes, description to various fields

### DIFF
--- a/execution_engine2.spec
+++ b/execution_engine2.spec
@@ -56,7 +56,7 @@ module execution_engine2 {
     */
     funcdef list_config() returns (mapping<string, string>) authentication optional;
 
-    /* Returns the current running version of the NarrativeJobService as a semantic version string. */
+    /* Returns the current running version of the execution_engine2 servicve as a semantic version string. */
     funcdef ver() returns (string);
 
     /* Simply check the status of this service to see queue details */

--- a/execution_engine2.spec
+++ b/execution_engine2.spec
@@ -270,12 +270,14 @@ module execution_engine2 {
             4 - job was missing its automated output document
             5 - job authentication token expired
         errormsg - string - message (e.g. stacktrace) accompanying an errored job
+        error - object - the JSON-RPC error package that accompanies the error code and message
 
         terminated_code - int - internal reason why a job was terminated, one of:
             0 - user cancellation
             1 - admin cancellation
             2 - terminated by some automatic process
 
+        @optional error
         @optional error_code
         @optional errormsg
         @optional terminated_code
@@ -299,6 +301,7 @@ module execution_engine2 {
         timestamp running;
         timestamp finished;
 
+        JsonRpcError error;
         int error_code;
         string errormsg;
 

--- a/execution_engine2.spec
+++ b/execution_engine2.spec
@@ -36,7 +36,24 @@ module execution_engine2 {
         string git_commit;
     } Status;
 
-    /* Returns the service configuration, including URL endpoints and timeouts */
+    /*
+        Returns the service configuration, including URL endpoints and timeouts.
+        The returned values are:
+        external-url - string - url of this service
+        kbase-endpoint - string - url of the services endpoint for the KBase environment
+        workspace-url - string - Workspace service url
+        catalog-url - string - catalog service url
+        shock-url - string - shock service url
+        handle-url - string - handle service url
+        auth-service-url - string - legacy auth service url
+        auth-service-url-v2 - string - current auth service url
+        auth-service-url-allow-insecure - boolean string (true or false) - whether to allow insecure requests
+        scratch - string - local path to scratch directory
+        executable - string - name of Job Runner executable
+        docker_timeout - int - time in seconds before a job will be timed out and terminated
+        initial_dir - string - initial dir for HTCondor to search for passed input/output files
+        transfer_input_files - initial list of files to transfer to HTCondor for job running
+    */
     funcdef list_config() returns (mapping<string, string>) authentication optional;
 
     /* Returns the current running version of the NarrativeJobService as a semantic version string. */


### PR DESCRIPTION
This is just an update to the notes and formatting of the execution_engine2.spec file (for now).

Really, I just wanted to document somewhere other than the code what each field is and what's available. I don't have the list of allowed projection strings yet, but I'm guessing they map onto the class names from `lib/execution_engine2/models/models.py`?

I also want to just throw out a recommendation here to change the returned name of "_id" (which is a mongoism/database-ism) to either "id" or "job_id". I'd prefer "job_id", since that's used throughout the rest of the ee2 API.