### PR TITLE
convert _id to job_id in returned job state

### DIFF
--- a/lib/execution_engine2/utils/MongoUtil.py
+++ b/lib/execution_engine2/utils/MongoUtil.py
@@ -18,7 +18,6 @@ from lib.execution_engine2.models.models import JobLog, Job, Status, TerminatedC
 
 class MongoUtil:
     def _start_local_service(self):
-
         try:
             start_local = int(self.config.get("start-local-mongo", 0))
         except Exception:
@@ -56,15 +55,15 @@ class MongoUtil:
     @classmethod
     def _get_collection(
         self,
-        mongo_host,
-        mongo_port,
-        mongo_database,
-        mongo_user=None,
-        mongo_password=None,
-        mongo_authmechanism="DEFAULT",
+        mongo_host: str,
+        mongo_port: int,
+        mongo_database: str,
+        mongo_user: str=None,
+        mongo_password: str=None,
+        mongo_authmechanism: str="DEFAULT",
     ):
         """
-        connect Mongo server and return a collection
+        Connect to Mongo server and return a tuple with the MongoClient and MongoClient?
         """
 
         if mongo_user:
@@ -100,7 +99,7 @@ class MongoUtil:
         try:
             pymongo_client.server_info()  # force a call to server
         except ServerSelectionTimeoutError as e:
-            error_msg = "Connot connect to Mongo server\n"
+            error_msg = "Cannot connect to Mongo server\n"
             error_msg += "ERROR -- {}:\n{}".format(
                 e, "".join(traceback.format_exception(None, e, e.__traceback__))
             )
@@ -108,7 +107,7 @@ class MongoUtil:
 
         return pymongo_client, mongoengine_client
 
-    def __init__(self, config):
+    def __init__(self, config: dict):
         self.config = config
         self.mongo_host = config["mongo-host"]
         self.mongo_port = int(config["mongo-port"])
@@ -147,7 +146,7 @@ class MongoUtil:
         finally:
             mc.close()
 
-    def get_job_log(self, job_id=None) -> JobLog:
+    def get_job_log(self, job_id: str=None) -> JobLog:
         if job_id is None:
             raise ValueError("Please provide a job id")
         with self.mongo_engine_connection():

--- a/lib/execution_engine2/utils/SDKMethodRunner.py
+++ b/lib/execution_engine2/utils/SDKMethodRunner.py
@@ -782,7 +782,8 @@ class SDKMethodRunner:
         job_states = dict()
         for job in jobs:
             mongo_rec = job.to_mongo().to_dict()
-            mongo_rec['_id'] = str(job.id)
+            del mongo_rec['_id']
+            mongo_rec['job_id'] = str(job.id)
             mongo_rec['created'] = str(job.id.generation_time)
             mongo_rec['updated'] = str(job.updated)
             if job.estimating:

--- a/test/ee2_SDKMethodRunner_test.py
+++ b/test/ee2_SDKMethodRunner_test.py
@@ -25,7 +25,11 @@ from execution_engine2.utils.Condor import submission_info
 from execution_engine2.utils.MongoUtil import MongoUtil
 from execution_engine2.utils.SDKMethodRunner import SDKMethodRunner
 from test.mongo_test_helper import MongoTestHelper
-from test.test_utils import bootstrap, get_example_job
+from test.test_utils import (
+    bootstrap,
+    get_example_job,
+    validate_job_state
+)
 
 logging.basicConfig(level=logging.INFO)
 bootstrap()
@@ -823,8 +827,10 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
             # test check_job
             job_state = runner.check_job(job_id, ctx)
             json.dumps(job_state)  # make sure it's JSON serializable
+            self.assertTrue(validate_job_state(job_state))
             self.assertEqual(job_state["status"], "created")
             self.assertEqual(job_state["wsid"], 9999)
+
 
             # test check_job with projection
             job_state = runner.check_job(job_id, ctx, projection=["status"])
@@ -834,6 +840,7 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
             # test check_jobs
             job_states = runner.check_jobs([job_id], ctx)
             json.dumps(job_states)  # make sure it's JSON serializable
+            self.assertTrue(validate_job_state(job_states[job_id]))
             self.assertTrue(job_id in job_states)
             self.assertEqual(job_states[job_id]["status"], "created")
             self.assertEqual(job_states[job_id]["wsid"], 9999)
@@ -846,6 +853,8 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
 
             # test check_workspace_jobs
             job_states = runner.check_workspace_jobs(9999, ctx)
+            for job_id in job_states:
+                self.assertTrue(job_states[job_id])
             json.dumps(job_states)  # make sure it's JSON serializable
             self.assertTrue(job_id in job_states)
             self.assertEqual(job_states[job_id]["status"], "created")

--- a/test/ee2_scheduler_integration_test.py
+++ b/test/ee2_scheduler_integration_test.py
@@ -10,7 +10,6 @@ logging.basicConfig(level=logging.INFO)
 
 from lib.execution_engine2.utils.Condor import Condor
 
-
 class ExecutionEngine2SchedulerIntegrationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,6 +4,7 @@ from dotenv import load_dotenv
 import pathlib
 from shutil import copyfile
 from execution_engine2.models.models import Job, JobInput, Meta
+from dateutil import parser as dateparser
 
 
 def get_example_job():
@@ -52,3 +53,118 @@ def bootstrap():
     if not os.path.exists(test_env):
         copyfile(f"{pwd}/test/env/{test_env}", f"{test_env}")
     load_dotenv("test.env", verbose=True)
+
+
+def validate_job_state(state):
+    """
+    Validates whether a returned Job State has all the required fields with the right format.
+    If all is well, returns True,
+    otherwise this prints out errors to the command line and returns False.
+    Can be just used with assert in tests, like "assert validate_job_state(state)"
+    """
+    required_fields = {
+        "job_id": str,
+        "user": str,
+        "wsid": int,
+        "authstrat": str,
+        "job_input": dict,
+        "updated": str,
+        "created": str,
+        "status": str,
+    }
+
+    optional_fields = {
+        "estimating": str,
+        "queued": str,
+        "running": str,
+        "finished": str,
+        "error_code": int,
+        "terminated_code": int,
+        "errormsg": str,
+    }
+
+    timestamp_fields = [
+        "created",
+        "updated",
+        "estimating",
+        "queued",
+        "running",
+        "finished"
+    ]
+
+    # fields that have to be present based on the context of different statuses
+    valid_statuses = [
+        "created",
+        "estimating",
+        "queued",
+        "running",
+        "finished",
+        "terminated",
+        "error"
+    ]
+
+    status_context = {
+        "estimating": ["estimating"],
+        "running": ["running"],
+        "finished": ["finished"],
+        "error": ["error_code", "errormsg"],
+        "terminated": ["terminated_code"]
+    }
+
+    # 1. Make sure required fields are present and of the correct type
+    missing_reqs = list()
+    wrong_reqs = list()
+    for req in required_fields.keys():
+        if req not in state:
+            missing_reqs.append(req)
+        elif not isinstance(state[req], required_fields[req]):
+            wrong_reqs.append(req)
+
+    if missing_reqs or wrong_reqs:
+        print(f"Job state is missing required fields: {missing_reqs}.")
+        for req in wrong_reqs:
+            print(f"Job state has faulty req - {req} should be of type {required_fields[req]}, but had value {state[req]}.")
+        return False
+
+    # 2. Make sure that context-specific fields are present and the right type
+    status = state['status']
+    if status not in valid_statuses:
+        print(f"Job state has invalid status {status}.")
+        return False
+
+    if status in status_context:
+        context_fields = status_context[status]
+        missing_context = list()
+        wrong_context = list()
+        for field in context_fields:
+            if field not in state:
+                missing_context.append(field)
+            elif not isinstance(state[field], optional_fields[field]):
+                wrong_context.append(field)
+        if missing_context or wrong_context:
+            print(f"Job state is missing status context fields: {missing_context}.")
+            for field in wrong_context:
+                print(f"Job state has faulty context field - {field} should be of type {optional_fields[field]}, but had value {state[field]}.")
+            return False
+
+    # 3. Make sure timestamps are really timestamps
+    bad_ts = list()
+    for ts_type in timestamp_fields:
+        if ts_type in state and not _is_timestamp(state[ts_type]):
+            bad_ts.append(ts_type)
+    if bad_ts:
+        for ts_type in bad_ts:
+            print(f"Job state has a malformatted timestamp: {ts_type} with value {state[ts_type]}")
+
+    return True
+
+def _is_timestamp(ts: str):
+    """
+    Simple enough - if dateutil.parser likes the string, it's a time string and we return True.
+    Otherwise, return False.
+    """
+    try:
+        dateparser.parse(ts)
+        return True
+    except:
+        return False

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -166,5 +166,5 @@ def _is_timestamp(ts: str):
     try:
         dateparser.parse(ts)
         return True
-    except:
+    except ValueError:
         return False


### PR DESCRIPTION
Works toward #47 , specifically converts _id in the returned job state to "job_id", and adds reasonably exhaustive validation tests to the non-projected job_state structure.