### PR TITLE
fix intialdir and initial_dir -> initialdir as in deploy.cfg

### DIFF
--- a/lib/execution_engine2/execution_engine2Impl.py
+++ b/lib/execution_engine2/execution_engine2Impl.py
@@ -13,7 +13,7 @@ class execution_engine2:
     execution_engine2
 
     Module Description:
-    
+
     '''
 
     ######## WARNING FOR GEVENT USERS ####### noqa
@@ -54,7 +54,7 @@ class execution_engine2:
                        'shock-url', 'handle-url', 'auth-service-url', 'auth-service-url-v2',
                        'auth-service-url-allow-insecure',
                        'scratch', 'executable', 'docker_timeout',
-                       'intialdir', 'transfer_input_files']
+                       'initialdir', 'transfer_input_files']
 
         returnVal = {key: self.config.get(key) for key in public_keys}
 

--- a/lib/execution_engine2/utils/Condor.py
+++ b/lib/execution_engine2/utils/Condor.py
@@ -40,7 +40,7 @@ class Condor(Scheduler):
     AUTH_TOKEN = "KB_ADMIN_AUTH_TOKEN"
     DOCKER_TIMEOUT = "docker_timeout"
     POOL_USER = "pool_user"
-    INITIAL_DIR = "initial_dir"
+    INITIAL_DIR = "initialdir"
     LEAVE_JOB_IN_QUEUE = "leavejobinqueue"
     TRANSFER_INPUT_FILES = "transfer_input_files"
     PYTHON_EXECUTABLE = "PYTHON_EXECUTABLE"


### PR DESCRIPTION
I took the `deploy.cfg` file as the point of truth and converted other references to the "initialdir" field to be in compliance.