### PR TITLE
DataUp-181 Prevent Reaper from quitting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # execution_engine2 (ee2) release notes
 =========================================
+## 0.0.3.4
+  * Change 7 day periodic_remove to 7 day hold
+  * Prevent reaper from prematurely exiting
+  
 ## 0.0.3.3
   * Change log appends from update to $push
   * Change first log linepos to position 0 instead of 1

--- a/bin/PurgeHeldJobs.py
+++ b/bin/PurgeHeldJobs.py
@@ -173,4 +173,4 @@ if __name__ == "__main__":
             time.sleep(5)
         except Exception as e:
             slack_client.ee2_reaper_failure(endpoint=ee2_endpoint)
-            sys.exit(f"{e}")
+


### PR DESCRIPTION
# Description of PR purpose/changes

Prevent the job reaper from exiting on error, just continue trying to reap

# Testing Instructions
Didn't write tests for this script.

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
