### PR TITLE
DATAUP-181 Change periodic remove, to periodic hold

### DIFF
--- a/lib/execution_engine2/utils/Condor.py
+++ b/lib/execution_engine2/utils/Condor.py
@@ -201,7 +201,7 @@ class Condor(Scheduler):
         #  Allow up to 12 hours for condor drain
         sub["MaxJobRetirementTime"] = "43200"
         # Remove jobs running longer than 7 days
-        sub["Periodic_Remove"] = "( RemoteWallClockTime > 604800 )"
+        sub["Periodic_Hold"] = "( RemoteWallClockTime > 604800 )"
         sub["log"] = "runner_logs/$(Cluster).$(Process).log"
         err_file = f"{job_id}.err"
         out_file = f"{job_id}.out"


### PR DESCRIPTION
# Description of PR purpose/changes

Jobs are removed so they do not update ee2
However, if we put them on hold, the hold reaper will capture them and mark them correctly. 

# Testing Instructions
I didn't test it, I just read the documentation

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

