### PR TITLE
Business logic for runjob batch tests 

### DIFF
--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2RunjobBatch_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2RunjobBatch_test.py
@@ -1,0 +1,25 @@
+# Probably need more comprehensive integration tests, not sure which can be tested in this repo
+
+# Case 1: User submits batch job. All parameters are good. Condor submission is good
+# * Endpoint returns list of job ids
+# * Jobs get submitted to condor. They start running and either crash or suceed
+# User gets notified via the UI on the return of `run_job_batch` that there is an issue
+
+
+# Case 2: User submits batch job. One or more parameters are bad.
+# * Endpoint returns an error ("one or more parameters are bad")
+# * No jobs are submitted to condor
+# User gets notified via the UI on the return of `run_job_batch` that there is an issue
+
+# Case 3: User submits batch job. All parameters are good.
+# * Endpoint returns list of job ids
+# * Thread submits jobs. Upon failure, jobs failed submit, does the entire batch abort? #TODO Look into it
+# * If the entire batch aborts or some make it through, run a canceljob on all failures and successes.
+# Not sure how we notify the user. Do we add logs into each job? Do we do something to the parent job? How do we tell the main cell that something went wrong?
+
+# Case 4: User submits batch job. All parameters are good. But job submission thread dies. Or ee2 dies. Or something else dies
+# * Endpoint returns a list of job_ids
+# * CreatedJobs Reaper runs...
+# * If job is in created state for longer than 5 minutes, has a parent_job, then fetch parent_job, and cancel all child jobs via ee2.cancel_job
+# (which calls a condor_rm on each of the jobs as well)
+# # Not sure how we notify the user. Do we add logs into each job? Do we do something to the parent job? How do we tell the main cell that something went wrong?


### PR DESCRIPTION
# Description of PR purpose/changes

* actually turns into thread
* adds more handling of failure modes
* adds more testing

# Jira Ticket / Github Issue #
- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [ ] Tests pass in travis and locally 
- [ ] Changes available by spinning up a local test suite and doing X

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
