### PR TITLE
Make token and user id required for sdkmr

### DIFF
--- a/lib/execution_engine2/sdk/EE2StatusRange.py
+++ b/lib/execution_engine2/sdk/EE2StatusRange.py
@@ -74,18 +74,12 @@ class JobStatusRange:
         if offset is None:
             offset = 0
 
-        if self.sdkmr.token is None:
-            raise AuthError("Please provide a token to check jobs date range")
-
-        token_user = self.sdkmr.auth.get_user(self.sdkmr.token)
-        if user is None:
-            user = token_user
-
         # Admins can view "ALL" or check_jobs for other users
-        if user != token_user:
+        if user != self.sdkmr.user_id:
             if not self.sdkmr.check_is_admin():
                 raise AuthError(
-                    f"You are not authorized to view all records or records for others. user={user} token={token_user}"
+                    "You are not authorized to view all records or records for others. "
+                    + f"user={user} token={self.sdkmr.user_id}"
                 )
 
         dummy_ids = self._get_dummy_dates(creation_start_time, creation_end_time)

--- a/lib/execution_engine2/sdk/SDKMethodRunner.py
+++ b/lib/execution_engine2/sdk/SDKMethodRunner.py
@@ -59,12 +59,16 @@ class SDKMethodRunner:
     def __init__(
         self,
         config,
-        user_id=None,
-        token=None,
+        user_id: str,
+        token: str,
         job_permission_cache=None,
         admin_permissions_cache=None,
         mongo_util=None,
     ):
+        if not user_id or not user_id.strip():
+            raise ValueError("user_id is required")
+        if not token or not token.strip():
+            raise ValueError("token is required")
         self.deployment_config_fp = os.environ["KB_DEPLOYMENT_CONFIG"]
         self.config = config
         self.mongo_util = mongo_util

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -9,6 +9,7 @@ from configparser import ConfigParser
 from datetime import datetime, timedelta
 from pprint import pprint
 from unittest.mock import patch
+from pytest import raises
 
 import bson
 import dateutil
@@ -37,6 +38,7 @@ bootstrap()
 from lib.execution_engine2.sdk.EE2Runjob import EE2RunJob
 
 
+# TODO this isn't necessary with pytest, can just use regular old functions
 class ee2_SDKMethodRunner_test(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -120,6 +122,21 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
     #     self.assertTrue(isinstance(git_commit_2, str))
     #     self.assertEqual(len(git_commit_1), len(git_commit_2))
     #    self.assertNotEqual(git_commit_1, git_commit_2)
+
+    def assert_exception_correct(self, got: Exception, expected: Exception):
+        assert got.args == expected.args
+        assert type(got) == type(expected)
+
+    def test_init_fail(self):
+        self._init_fail({}, None, "foo", ValueError("user_id is required"))
+        self._init_fail({}, "   \t  ", "foo", ValueError("user_id is required"))
+        self._init_fail({}, "user", None, ValueError("token is required"))
+        self._init_fail({}, "user", "   \t  ", ValueError("token is required"))
+
+    def _init_fail(self, cfg, user, token, expected):
+        with raises(Exception) as e:
+            SDKMethodRunner(cfg, user, token)
+        self.assert_exception_correct(e.value, expected)
 
     # Status
     @patch("lib.execution_engine2.utils.Condor.Condor", autospec=True)


### PR DESCRIPTION
# Description of PR purpose/changes

SDKMR allows passing in `None` for the user id and token in the constructor, but there are no cases where this functionality is actually used. Simplify the code by requiring user credentials at initialization.

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - too many warnings to reasonably tell
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
