### PR TITLE
Start up ee2 service in api to db test

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,4 +9,6 @@ exclude =
  execution_engine2Impl.py,
  lib/installed_clients/,
  lib/execution_engine2/execution_engine2Impl.py,
+ lib/execution_engine2/authclient.py,
+ lib/biokbase/log.py,
  *Impl.py

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  generated:
+    - lib/biokbase/log.py

--- a/lib/biokbase/README.md
+++ b/lib/biokbase/README.md
@@ -1,0 +1,3 @@
+log.py lives here: https://raw.githubusercontent.com/kbase/sdkbase2/python/log.py
+
+However, it's needed to run tests so it's checked into this repo.

--- a/lib/biokbase/log.py
+++ b/lib/biokbase/log.py
@@ -1,0 +1,368 @@
+"""
+NAME
+       log
+
+DESCRIPTION
+       A library for sending logging messages to syslog.
+
+METHODS
+       log(string subsystem, hashref constraints): Initializes log. You
+           should call this at the beginning of your program. Constraints are
+           optional.
+
+       log_message(int level, string message): sends log message to syslog.
+
+       *         level: (0-9) The logging level for this message is compared to
+                    the logging level that has been set in log.  If it is <=
+                    the set logging level, the message will be sent to syslog,
+                    otherwise it will be ignored.  Logging level is set to 6
+                    if control API cannot be reached and the user does
+                    not set the log level. Log level can also be entered as
+                    string (e.g. 'DEBUG')
+
+       *          message: This is the log message.
+
+       get_log_level(): Returns the current log level as an integer.
+
+       set_log_level(integer level) : Sets the log level. Only use this if you
+           wish to override the log levels that are defined by the control API.
+           Can also be entered as string (e.g. 'DEBUG')
+
+       *          level : priority
+
+       *          0 : EMERG - system is unusable
+
+       *          1 : ALERT - component must be fixed immediately
+
+       *          2 : CRIT - secondary component must be fixed immediately
+
+       *          3 : ERR - non-urgent failure
+
+       *          4 : WARNING - warning that an error will occur if no action
+                                is taken
+
+       *          5 : NOTICE - unusual but safe conditions
+
+       *          6 : INFO - normal operational messages
+
+       *          7 : DEBUG - lowest level of debug
+
+       *          8 : DEBUG2 - second level of debug
+
+       *          9 : DEBUG3 - highest level of debug
+
+       set_log_msg_check_count(integer count): used to set the number the
+           messages that log will log before querying the control API for the
+           log level (default is 100 messages).
+
+       set_log_msg_check_interval(integer seconds): used to set the interval,
+           in seconds, that will be allowed to pass before log will query the
+           control API for the log level (default is 300 seconds).
+
+       update_api_log_level() : Checks the control API for the currently set
+           log level.
+
+       use_api_log_level() : Removes the user-defined log level and tells log
+           to use the control API-defined log level.
+"""
+
+import json as _json
+import urllib.request as _urllib2
+import syslog as _syslog
+import platform as _platform
+import inspect as _inspect
+import os as _os
+import getpass as _getpass
+import warnings as _warnings
+from configparser import ConfigParser as _ConfigParser
+import time
+
+MLOG_ENV_FILE = 'MLOG_CONFIG_FILE'
+_GLOBAL = 'global'
+MLOG_LOG_LEVEL = 'mlog_log_level'
+MLOG_API_URL = 'mlog_api_url'
+MLOG_LOG_FILE = 'mlog_log_file'
+
+DEFAULT_LOG_LEVEL = 6
+#MSG_CHECK_COUNT = 100
+#MSG_CHECK_INTERVAL = 300  # 300s = 5min
+MSG_FACILITY = _syslog.LOG_LOCAL1
+EMERG_FACILITY = _syslog.LOG_LOCAL0
+
+EMERG = 0
+ALERT = 1
+CRIT = 2
+ERR = 3
+WARNING = 4
+NOTICE = 5
+INFO = 6
+DEBUG = 7
+DEBUG2 = 8
+DEBUG3 = 9
+_MLOG_TEXT_TO_LEVEL = {'EMERG': EMERG,
+                      'ALERT': ALERT,
+                      'CRIT': CRIT,
+                      'ERR': ERR,
+                      'WARNING': WARNING,
+                      'NOTICE': NOTICE,
+                      'INFO': INFO,
+                      'DEBUG': DEBUG,
+                      'DEBUG2': DEBUG2,
+                      'DEBUG3': DEBUG3,
+                      }
+_MLOG_TO_SYSLOG = [_syslog.LOG_EMERG, _syslog.LOG_ALERT, _syslog.LOG_CRIT,
+                 _syslog.LOG_ERR, _syslog.LOG_WARNING, _syslog.LOG_NOTICE,
+                 _syslog.LOG_INFO, _syslog.LOG_DEBUG, _syslog.LOG_DEBUG,
+                 _syslog.LOG_DEBUG]
+#ALLOWED_LOG_LEVELS = set(_MLOG_TEXT_TO_LEVEL.values())
+_MLOG_LEVEL_TO_TEXT = {}
+for k, v in _MLOG_TEXT_TO_LEVEL.items():
+    _MLOG_LEVEL_TO_TEXT[v] = k
+LOG_LEVEL_MIN = min(_MLOG_LEVEL_TO_TEXT.keys())
+LOG_LEVEL_MAX = max(_MLOG_LEVEL_TO_TEXT.keys())
+del k, v
+
+
+class log(object):
+    """
+    This class contains the methods necessary for sending log messages.
+    """
+
+    def __init__(self, subsystem, constraints=None, config=None, logfile=None,
+                 ip_address=False, authuser=False, module=False,
+                 method=False, call_id=False, changecallback=None):
+        if not subsystem:
+            raise ValueError("Subsystem must be supplied")
+
+        self.user = _getpass.getuser()
+        self.parentfile = _os.path.abspath(_inspect.getfile(
+            _inspect.stack()[1][0]))
+        self.ip_address = ip_address
+        self.authuser = authuser
+        self.module = module
+        self.method = method
+        self.call_id = call_id
+        noop = lambda: None
+        self._callback = changecallback or noop
+        self._subsystem = str(subsystem)
+        self._mlog_config_file = config
+        if not self._mlog_config_file:
+            self._mlog_config_file = _os.environ.get(MLOG_ENV_FILE, None)
+        if self._mlog_config_file:
+            self._mlog_config_file = str(self._mlog_config_file)
+        self._user_log_level = -1
+        self._config_log_level = -1
+        self._user_log_file = logfile
+        self._config_log_file = None
+        self._api_log_level = -1
+        self._msgs_since_config_update = 0
+        self._time_at_config_update = time.time()
+        self.msg_count = 0
+        self._recheck_api_msg = 100
+        self._recheck_api_time = 300  # 5 mins
+        self._log_constraints = {} if not constraints else constraints
+
+        self._init = True
+        self.update_config()
+        self._init = False
+
+    def _get_time_since_start(self):
+        time_diff = time.time() - self._time_at_config_update
+        return time_diff
+
+    def get_log_level(self):
+        if(self._user_log_level != -1):
+            return self._user_log_level
+        elif(self._config_log_level != -1):
+            return self._config_log_level
+        elif(self._api_log_level != -1):
+            return self._api_log_level
+        else:
+            return DEFAULT_LOG_LEVEL
+
+    def _get_config_items(self, cfg, section):
+        cfgitems = {}
+        if cfg.has_section(section):
+            for k, v in cfg.items(section):
+                cfgitems[k] = v
+        return cfgitems
+
+    def update_config(self):
+        loglevel = self.get_log_level()
+        logfile = self.get_log_file()
+
+        self._api_log_level = -1
+        self._msgs_since_config_update = 0
+        self._time_at_config_update = time.time()
+
+        # Retrieving the control API defined log level
+        api_url = None
+        if self._mlog_config_file and _os.path.isfile(self._mlog_config_file):
+            cfg = _ConfigParser()
+            cfg.read(self._mlog_config_file)
+            cfgitems = self._get_config_items(cfg, _GLOBAL)
+            cfgitems.update(self._get_config_items(cfg, self._subsystem))
+            if MLOG_LOG_LEVEL in cfgitems:
+                try:
+                    self._config_log_level = int(cfgitems[MLOG_LOG_LEVEL])
+                except:
+                    _warnings.warn(
+                        'Cannot parse log level {} from file {} to int'.format(
+                            cfgitems[MLOG_LOG_LEVEL], self._mlog_config_file)
+                        + '. Keeping current log level.')
+            if MLOG_API_URL in cfgitems:
+                api_url = cfgitems[MLOG_API_URL]
+            if MLOG_LOG_FILE in cfgitems:
+                self._config_log_file = cfgitems[MLOG_LOG_FILE]
+        elif self._mlog_config_file:
+            _warnings.warn('Cannot read config file ' + self._mlog_config_file)
+
+        if (api_url):
+            subsystem_api_url = api_url + "/" + self._subsystem
+            try:
+                data = _json.load(_urllib2.urlopen(subsystem_api_url,
+                                                   timeout=5))
+            except _urllib2.URLError as e:
+                code_ = None
+                if hasattr(e, 'code'):
+                    code_ = ' ' + str(e.code)
+                _warnings.warn(
+                    'Could not connect to mlog api server at ' +
+                    '{}:{} {}. Using default log level {}.'.format(
+                    subsystem_api_url, code_, str(e.reason),
+                    str(DEFAULT_LOG_LEVEL)))
+            else:
+                max_matching_level = -1
+                for constraint_set in data['log_levels']:
+                    level = constraint_set['level']
+                    constraints = constraint_set['constraints']
+                    if level <= max_matching_level:
+                        continue
+
+                    matches = 1
+                    for constraint in constraints:
+                        if constraint not in self._log_constraints:
+                            matches = 0
+                        elif (self._log_constraints[constraint] !=
+                              constraints[constraint]):
+                            matches = 0
+
+                    if matches == 1:
+                        max_matching_level = level
+
+                self._api_log_level = max_matching_level
+        if ((self.get_log_level() != loglevel or
+             self.get_log_file() != logfile) and not self._init):
+            self._callback()
+
+    def _resolve_log_level(self, level):
+        if(level in _MLOG_TEXT_TO_LEVEL):
+            level = _MLOG_TEXT_TO_LEVEL[level]
+        elif(level not in _MLOG_LEVEL_TO_TEXT):
+            raise ValueError('Illegal log level')
+        return level
+
+    def set_log_level(self, level):
+        self._user_log_level = self._resolve_log_level(level)
+        self._callback()
+
+    def get_log_file(self):
+        if self._user_log_file:
+            return self._user_log_file
+        if self._config_log_file:
+            return self._config_log_file
+        return None
+
+    def set_log_file(self, filename):
+        self._user_log_file = filename
+        self._callback()
+
+    def set_log_msg_check_count(self, count):
+        count = int(count)
+        if count < 0:
+            raise ValueError('Cannot check a negative number of messages')
+        self._recheck_api_msg = count
+
+    def set_log_msg_check_interval(self, interval):
+        interval = int(interval)
+        if interval < 0:
+            raise ValueError('interval must be positive')
+        self._recheck_api_time = interval
+
+    def clear_user_log_level(self):
+        self._user_log_level = -1
+        self._callback()
+
+    def _get_ident(self, level, user, parentfile, ip_address, authuser, module,
+                   method, call_id):
+        infos = [self._subsystem, _MLOG_LEVEL_TO_TEXT[level],
+                 repr(time.time()), user, parentfile, str(_os.getpid())]
+        if self.ip_address:
+            infos.append(str(ip_address) if ip_address else '-')
+        if self.authuser:
+            infos.append(str(authuser) if authuser else '-')
+        if self.module:
+            infos.append(str(module) if module else '-')
+        if self.method:
+            infos.append(str(method) if method else '-')
+        if self.call_id:
+            infos.append(str(call_id) if call_id else '-')
+        return "[" + "] [".join(infos) + "]"
+
+    def _syslog(self, facility, level, ident, message):
+        _syslog.openlog(ident, facility)
+        if isinstance(message, str):
+            _syslog.syslog(_MLOG_TO_SYSLOG[level], message)
+        else:
+            try:
+                for m in message:
+                    _syslog.syslog(_MLOG_TO_SYSLOG[level], m)
+            except TypeError:
+                _syslog.syslog(_MLOG_TO_SYSLOG[level], str(message))
+        _syslog.closelog()
+
+    def _log(self, ident, message):
+        ident = ' '.join([str(time.strftime(
+            "%Y-%m-%d %H:%M:%S", time.localtime())),
+                        _platform.node(), ident + ': '])
+        try:
+            with open(self.get_log_file(), 'a') as log:
+                if isinstance(message, str):
+                    log.write(ident + message + '\n')
+                else:
+                    try:
+                        for m in message:
+                            log.write(ident + m + '\n')
+                    except TypeError:
+                        log.write(ident + str(message) + '\n')
+        except Exception as e:
+            err = 'Could not write to log file ' + str(self.get_log_file()) + \
+                ': ' + str(e) + '.'
+            _warnings.warn(err)
+
+    def log_message(self, level, message, ip_address=None, authuser=None,
+                    module=None, method=None, call_id=None):
+#        message = str(message)
+        level = self._resolve_log_level(level)
+
+        self.msg_count += 1
+        self._msgs_since_config_update += 1
+
+        if(self._msgs_since_config_update >= self._recheck_api_msg
+           or self._get_time_since_start() >= self._recheck_api_time):
+            self.update_config()
+
+        ident = self._get_ident(level, self.user, self.parentfile, ip_address,
+                                authuser, module, method, call_id)
+        # If this message is an emergency, send a copy to the emergency
+        # facility first.
+        if(level == 0):
+            self._syslog(EMERG_FACILITY, level, ident, message)
+
+        if(level <= self.get_log_level()):
+            self._syslog(MSG_FACILITY, level, ident, message)
+            if self.get_log_file():
+                self._log(ident, message)
+
+if __name__ == '__main__':
+    pass

--- a/lib/execution_engine2/README.md
+++ b/lib/execution_engine2/README.md
@@ -1,0 +1,3 @@
+authclient.py lives here: https://github.com/kbase/kb_sdk/blob/master/src/java/us/kbase/templates/authclient.py
+
+... but is checked in as it's needed for tests.

--- a/lib/execution_engine2/authclient.py
+++ b/lib/execution_engine2/authclient.py
@@ -1,0 +1,94 @@
+'''
+Created on Aug 1, 2016
+
+A very basic KBase auth client for the Python server.
+
+@author: gaprice@lbl.gov
+'''
+import time as _time
+import requests as _requests
+import threading as _threading
+import hashlib
+
+
+class TokenCache(object):
+    ''' A basic cache for tokens. '''
+
+    _MAX_TIME_SEC = 5 * 60  # 5 min
+
+    _lock = _threading.RLock()
+
+    def __init__(self, maxsize=2000):
+        self._cache = {}
+        self._maxsize = maxsize
+        self._halfmax = maxsize / 2  # int division to round down
+
+    def get_user(self, token):
+        token = hashlib.sha256(token.encode('utf-8')).hexdigest()
+        with self._lock:
+            usertime = self._cache.get(token)
+        if not usertime:
+            return None
+
+        user, intime = usertime
+        if _time.time() - intime > self._MAX_TIME_SEC:
+            return None
+        return user
+
+    def add_valid_token(self, token, user):
+        if not token:
+            raise ValueError('Must supply token')
+        if not user:
+            raise ValueError('Must supply user')
+        token = hashlib.sha256(token.encode('utf-8')).hexdigest()
+        with self._lock:
+            self._cache[token] = [user, _time.time()]
+            if len(self._cache) > self._maxsize:
+                sorted_items = sorted(
+                    list(self._cache.items()),
+                    key=(lambda v: v[1][1])
+                )
+                for i, (t, _) in enumerate(sorted_items):
+                    if i <= self._halfmax:
+                        del self._cache[t]
+                    else:
+                        break
+
+
+class KBaseAuth(object):
+    '''
+    A very basic KBase auth client for the Python server.
+    '''
+
+    _LOGIN_URL = 'https://kbase.us/services/auth/api/legacy/KBase/Sessions/Login'
+
+    def __init__(self, auth_url=None):
+        '''
+        Constructor
+        '''
+        self._authurl = auth_url
+        if not self._authurl:
+            self._authurl = self._LOGIN_URL
+        self._cache = TokenCache()
+
+    def get_user(self, token):
+        if not token:
+            raise ValueError('Must supply token')
+        user = self._cache.get_user(token)
+        if user:
+            return user
+
+        d = {'token': token, 'fields': 'user_id'}
+        ret = _requests.post(self._authurl, data=d)
+        if not ret.ok:
+            try:
+                err = ret.json()
+            except Exception as e:
+                ret.raise_for_status()
+            raise ValueError('Error connecting to auth service: {} {}\n{}'
+                             .format(ret.status_code, ret.reason,
+                                     err['error']['message']))
+
+        user = ret.json()['user_id']
+        self._cache.add_valid_token(token, user)
+        return user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ exclude = '''
   | __pycache__
   | lib/__pycache__
   | lib/execution_engine2/execution_engine2Impl.py
+  | lib/execution_engine2/authclient.py
+  | lib/biokbase/*
   | lib/installed_clients/*
 )
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ exclude = '''
   | lib/__pycache__
   | lib/execution_engine2/execution_engine2Impl.py
   | lib/execution_engine2/authclient.py
-  | lib/biokbase/*
+  | lib/biokbase/log.py
   | lib/installed_clients/*
 )
 '''

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -10,11 +10,25 @@ If the latter, the test auth integration will likely need to be converted to a d
 exposed to other containers.
 """
 
+import os
+import tempfile
+import time
+
+from configparser import ConfigParser
+from threading import Thread
 from pathlib import Path
 import pymongo
 from pytest import fixture
+from typing import Dict
 from tests_for_integration.auth_controller import AuthController
-from utils_shared.test_utils import get_test_config
+from utils_shared.test_utils import (
+    get_full_test_config,
+    get_ee2_test_config,
+    EE2_CONFIG_SECTION,
+    find_free_port,
+)
+from execution_engine2 import execution_engine2Server
+from installed_clients.execution_engine2Client import execution_engine2 as ee2client
 
 KEEP_TEMP_FILES = True
 AUTH_DB = "api_to_db_test"
@@ -26,8 +40,13 @@ JARS_DIR = Path("/opt/jars/lib/jars")
 
 
 @fixture(scope="module")
-def config():
-    yield get_test_config()
+def config() -> Dict[str, str]:
+    yield get_ee2_test_config()
+
+
+@fixture(scope="module")
+def full_config() -> ConfigParser:
+    yield get_full_test_config()
 
 
 @fixture(scope="module")
@@ -84,12 +103,65 @@ def auth_url(config, mongo_client):
     _clean_auth_db(mongo_client)
 
 
-# TODO start the ee2 service
-# TODO wipe the ee2 database between every test
+# side effect: modifies the config
+def _create_config_file(full_config, auth_url):
+    ee2c = full_config[EE2_CONFIG_SECTION]
+    ee2c['auth-service-url'] = auth_url + "/api/legacy/KBase/Sessions/Login"
+    ee2c['auth-service-url-v2'] = auth_url + "/api/v2/token"
+    ee2c['auth-url'] = auth_url
+    ee2c['auth-service-url-allow-insecure'] = 'true'
+
+    deploy = tempfile.mkstemp('.cfg', 'deploy-', dir=TEMP_DIR, text=True)
+    os.close(deploy[0])
+
+    with open(deploy[1], 'w') as handle:
+        full_config.write(handle)
+
+    return deploy[1]
 
 
-def test_is_admin(auth_url):
-    import requests
+def _clear_ee2_db(mc: pymongo.MongoClient, config: Dict[str, str]):
+    ee2 = mc[config['mongo-database']]
+    for name in ee2.list_collection_names():
+        if not name.startswith('system.'):
+            # don't drop collection since that drops indexes
+            ee2.get_collection(name).delete_many({})
 
-    print(requests.get(auth_url).text)
+
+@fixture(scope="module")
+def service(full_config, auth_url, mongo_client, config):
+    cfgpath = _create_config_file(full_config, auth_url)
+    _clear_ee2_db(mongo_client, config)
+
+    # from this point on, calling the get_*_test_config methods will get the temp config file
+    os.environ['KB_DEPLOYMENT_CONFIG'] = cfgpath
+    portint = find_free_port()
+    Thread(
+        target=execution_engine2Server.start_server,
+        kwargs={'port': portint},
+        daemon=True
+    ).start()
+    time.sleep(0.05)
+    port = str(portint)
+    print('running ee2 service at localhost:' + port)
+    yield port
+
+    # shutdown the server
+    # SampleServiceServer.stop_server()  <-- this causes an error. the start & stop methods are
+    # bugged. _proc is only set if newprocess=True
+
+    if not KEEP_TEMP_FILES:
+        os.remove(cfgpath)
+
+
+@fixture
+def ee2_port(service, mongo_client, config):
+    _clear_ee2_db(mongo_client, config)
+
+    yield service
+
+
+def test_is_admin(ee2_port):
+    ee2cli = ee2client('http://localhost:' + ee2_port)
+    print(ee2cli.status())
     # TODO add a test

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -25,6 +25,7 @@ from utils_shared.test_utils import (
     get_full_test_config,
     get_ee2_test_config,
     EE2_CONFIG_SECTION,
+    KB_DEPLOY_ENV,
     find_free_port,
 )
 from execution_engine2 import execution_engine2Server
@@ -134,7 +135,7 @@ def service(full_config, auth_url, mongo_client, config):
     _clear_ee2_db(mongo_client, config)
 
     # from this point on, calling the get_*_test_config methods will get the temp config file
-    os.environ['KB_DEPLOYMENT_CONFIG'] = cfgpath
+    os.environ[KB_DEPLOY_ENV] = cfgpath
     portint = find_free_port()
     Thread(
         target=execution_engine2Server.start_server,

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -107,24 +107,24 @@ def auth_url(config, mongo_client):
 # side effect: modifies the config
 def _create_config_file(full_config, auth_url):
     ee2c = full_config[EE2_CONFIG_SECTION]
-    ee2c['auth-service-url'] = auth_url + "/api/legacy/KBase/Sessions/Login"
-    ee2c['auth-service-url-v2'] = auth_url + "/api/v2/token"
-    ee2c['auth-url'] = auth_url
-    ee2c['auth-service-url-allow-insecure'] = 'true'
+    ee2c["auth-service-url"] = auth_url + "/api/legacy/KBase/Sessions/Login"
+    ee2c["auth-service-url-v2"] = auth_url + "/api/v2/token"
+    ee2c["auth-url"] = auth_url
+    ee2c["auth-service-url-allow-insecure"] = "true"
 
-    deploy = tempfile.mkstemp('.cfg', 'deploy-', dir=TEMP_DIR, text=True)
+    deploy = tempfile.mkstemp(".cfg", "deploy-", dir=TEMP_DIR, text=True)
     os.close(deploy[0])
 
-    with open(deploy[1], 'w') as handle:
+    with open(deploy[1], "w") as handle:
         full_config.write(handle)
 
     return deploy[1]
 
 
 def _clear_ee2_db(mc: pymongo.MongoClient, config: Dict[str, str]):
-    ee2 = mc[config['mongo-database']]
+    ee2 = mc[config["mongo-database"]]
     for name in ee2.list_collection_names():
-        if not name.startswith('system.'):
+        if not name.startswith("system."):
             # don't drop collection since that drops indexes
             ee2.get_collection(name).delete_many({})
 
@@ -139,12 +139,12 @@ def service(full_config, auth_url, mongo_client, config):
     portint = find_free_port()
     Thread(
         target=execution_engine2Server.start_server,
-        kwargs={'port': portint},
-        daemon=True
+        kwargs={"port": portint},
+        daemon=True,
     ).start()
     time.sleep(0.05)
     port = str(portint)
-    print('running ee2 service at localhost:' + port)
+    print("running ee2 service at localhost:" + port)
     yield port
 
     # shutdown the server
@@ -163,6 +163,6 @@ def ee2_port(service, mongo_client, config):
 
 
 def test_is_admin(ee2_port):
-    ee2cli = ee2client('http://localhost:' + ee2_port)
+    ee2cli = ee2client("http://localhost:" + ee2_port)
     print(ee2cli.status())
     # TODO add a test

--- a/test/utils_shared/test_utils.py
+++ b/test/utils_shared/test_utils.py
@@ -459,7 +459,8 @@ def get_full_test_config() -> ConfigParser:
     config_parser.read(config_file)
     if config_parser[EE2_CONFIG_SECTION].get("mongo-in-docker-compose"):
         config_parser[EE2_CONFIG_SECTION]["mongo-host"] = config_parser[
-            EE2_CONFIG_SECTION]["mongo-in-docker-compose"]
+            EE2_CONFIG_SECTION
+        ]["mongo-in-docker-compose"]
     return config_parser
 
 

--- a/test/utils_shared/test_utils.py
+++ b/test/utils_shared/test_utils.py
@@ -17,6 +17,11 @@ from lib.execution_engine2.exceptions import MalformedTimestampException
 from lib.execution_engine2.utils.CondorTuples import CondorResources, JobInfo
 
 
+EE2_CONFIG_SECTION = "execution_engine2"
+KB_DEPLOY_ENV = "KB_DEPLOYMENT_CONFIG"
+DEFAULT_TEST_DEPLOY_CFG = "test/deploy.cfg"
+
+
 def bootstrap():
     test_env_0 = "../test.env"
     test_env_1 = "test.env"
@@ -440,19 +445,36 @@ def set_custom_roles(auth_url, user, roles):
         ret.raise_for_status()
 
 
-def get_test_config():
-    config_file = os.environ.get("KB_DEPLOYMENT_CONFIG", "test/deploy.cfg")
+def get_full_test_config() -> ConfigParser:
+    f"""
+    Gets the full configuration for ee2, including all sections of the config file.
+
+    If the {KB_DEPLOY_ENV} environment variable is set, loads the configuration from there.
+    Otherwise, the repo's {DEFAULT_TEST_DEPLOY_CFG} file is used.
+    """
+    config_file = os.environ.get(KB_DEPLOY_ENV, DEFAULT_TEST_DEPLOY_CFG)
     logging.info(f"Loading config from {config_file}")
 
     config_parser = ConfigParser()
     config_parser.read(config_file)
+    if config_parser[EE2_CONFIG_SECTION].get("mongo-in-docker-compose"):
+        config_parser[EE2_CONFIG_SECTION]["mongo-host"] = config_parser[
+            EE2_CONFIG_SECTION]["mongo-in-docker-compose"]
+    return config_parser
+
+
+def get_ee2_test_config() -> Dict[str, str]:
+    f"""
+    Gets the configuration for the ee2 service, e.g. the {EE2_CONFIG_SECTION} section of the
+    deploy.cfg file.
+
+    If the {KB_DEPLOY_ENV} environment variable is set, loads the configuration from there.
+    Otherwise, the repo's {DEFAULT_TEST_DEPLOY_CFG} file is used.
+    """
+    cp = get_full_test_config()
 
     cfg = {}
-
-    for nameval in config_parser.items("execution_engine2"):
+    for nameval in cp.items(EE2_CONFIG_SECTION):
         cfg[nameval[0]] = nameval[1]
 
-    mongo_in_docker = cfg.get("mongo-in-docker-compose", None)
-    if mongo_in_docker is not None:
-        cfg["mongo-host"] = cfg["mongo-in-docker-compose"]
     return cfg


### PR DESCRIPTION
# Description of PR purpose/changes

Starts the ee2 service as part of the API to DB tests. Next step is actually adding the is_admin test.

Manually verified that the status() is printed out correctly and that the tests pass in Docker.

To run an API to DB test I need to start the service. The service expects a
couple of files in specific places in the repo, so I had to check them in.

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] My changes generate no new warnings - 3000+ warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [X] [Version has been bumped](https://semver.org/) for each release
- [X] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
