### PR TITLE
Fix workspace client access bug & unit test

### DIFF
--- a/lib/execution_engine2/db/models/models.py
+++ b/lib/execution_engine2/db/models/models.py
@@ -111,6 +111,9 @@ class Meta(EmbeddedDocument):
     cell_id = StringField()
     status = StringField()
 
+    def __repr__(self):
+        return self.to_json()
+
 
 class CondorResourceUsage(EmbeddedDocument):
     """
@@ -147,6 +150,9 @@ class JobRequirements(EmbeddedDocument):
     disk = IntField()
     estimate = EmbeddedDocumentField(Estimate)
 
+    def __repr__(self):
+        return self.to_json()
+
 
 class JobInput(EmbeddedDocument):
     """
@@ -163,6 +169,9 @@ class JobInput(EmbeddedDocument):
     parent_job_id = StringField()
     requirements = EmbeddedDocumentField(JobRequirements)
     narrative_cell_info = EmbeddedDocumentField(Meta, required=True)
+
+    def __repr__(self):
+        return self.to_json()
 
 
 class JobOutput(EmbeddedDocument):

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -20,7 +20,7 @@ from lib.execution_engine2.db.models.models import (
 )
 from lib.execution_engine2.sdk.EE2Constants import ConciergeParams
 from lib.execution_engine2.utils.CondorTuples import CondorResources
-from lib.execution_engine2.utils.KafkaUtils import KafkaCreateJob, KafkaQueueChange
+from execution_engine2.utils.KafkaUtils import KafkaCreateJob, KafkaQueueChange
 
 
 class JobPermissions(Enum):
@@ -44,7 +44,7 @@ class EE2RunJob:
     def __init__(self, sdkmr):
         self.sdkmr = sdkmr  # type: SDKMethodRunner
         self.override_clientgroup = os.environ.get("OVERRIDE_CLIENT_GROUP", None)
-        self.logger = self.sdkmr.logger
+        self.logger = self.sdkmr.get_logger()
 
     def _init_job_rec(
         self,
@@ -100,15 +100,14 @@ class EE2RunJob:
         job.job_input = inputs
         self.logger.debug(job.job_input.to_mongo().to_dict())
 
-        with self.sdkmr.get_mongo_util().mongo_engine_connection():
-            self.logger.debug(job.to_mongo().to_dict())
-            job.save()
+        self.logger.debug(job.to_mongo().to_dict())
+        job_id = self.sdkmr.save_job(job)
 
-        self.sdkmr.kafka_client.send_kafka_message(
-            message=KafkaCreateJob(job_id=str(job.id), user=user_id)
+        self.sdkmr.get_kafka_client().send_kafka_message(
+            message=KafkaCreateJob(job_id=job_id, user=user_id)
         )
 
-        return str(job.id)
+        return job_id
 
     def _get_module_git_commit(self, method, service_ver=None) -> Optional[str]:
         module_name = method.split(".")[0]
@@ -118,7 +117,7 @@ class EE2RunJob:
 
         self.logger.debug(f"Getting commit for {module_name} {service_ver}")
 
-        module_version = self.sdkmr.catalog_utils.catalog.get_module_version(
+        module_version = self.sdkmr.get_catalog_utils().get_catalog().get_module_version(
             {"module_name": module_name, "version": service_ver}
         )
 
@@ -194,7 +193,7 @@ class EE2RunJob:
         self._check_ws_objects(source_objects=params.get("source_ws_objects"))
         method = params.get("method")
         # Normalize multiple formats into one format (csv vs json)
-        normalized_resources = self.sdkmr.catalog_utils.get_normalized_resources(method)
+        normalized_resources = self.sdkmr.get_catalog_utils().get_normalized_resources(method)
         # These are for saving into job inputs. Maybe its best to pass this into condor as well?
         extracted_resources = self.sdkmr.get_condor().extract_resources(
             cgrr=normalized_resources
@@ -202,16 +201,16 @@ class EE2RunJob:
         # insert initial job document into db
 
         job_id = self._init_job_rec(
-            self.sdkmr.user_id, params, extracted_resources, concierge_params
+            self.sdkmr.get_user_id(), params, extracted_resources, concierge_params
         )
 
         params["job_id"] = job_id
-        params["user_id"] = self.sdkmr.user_id
-        params["token"] = self.sdkmr.token
+        params["user_id"] = self.sdkmr.get_user_id()
+        params["token"] = self.sdkmr.get_token()
         params["cg_resources_requirements"] = normalized_resources
 
         self.logger.debug(
-            f"User {self.sdkmr.user_id} attempting to run job {method} {params}"
+            f"User {self.sdkmr.get_user_id()} attempting to run job {method} {params}"
         )
 
         return PreparedJobParams(params=params, job_id=job_id)
@@ -249,8 +248,8 @@ class EE2RunJob:
         )
 
         self.update_job_to_queued(job_id=job_id, scheduler_id=condor_job_id)
-        self.sdkmr.slack_client.run_job_message(
-            job_id=job_id, scheduler_id=condor_job_id, username=self.sdkmr.user_id
+        self.sdkmr.get_slack_client().run_job_message(
+            job_id=job_id, scheduler_id=condor_job_id, username=self.sdkmr.get_user_id()
         )
 
         return job_id
@@ -374,23 +373,22 @@ class EE2RunJob:
         # TODO RETRY FOR RACE CONDITION OF RUN/CANCEL
         # TODO PASS QUEUE TIME IN FROM SCHEDULER ITSELF?
         # TODO PASS IN SCHEDULER TYPE?
-        with self.sdkmr.get_mongo_util().mongo_engine_connection():
-            j = self.sdkmr.get_mongo_util().get_job(job_id=job_id)
-            previous_status = j.status
-            j.status = Status.queued.value
-            j.queued = time.time()
-            j.scheduler_id = scheduler_id
-            j.scheduler_type = "condor"
-            j.save()
+        j = self.sdkmr.get_mongo_util().get_job(job_id=job_id)
+        previous_status = j.status
+        j.status = Status.queued.value
+        j.queued = time.time()
+        j.scheduler_id = scheduler_id
+        j.scheduler_type = "condor"
+        self.sdkmr.save_job(j)
 
-            self.sdkmr.kafka_client.send_kafka_message(
-                message=KafkaQueueChange(
-                    job_id=str(j.id),
-                    new_status=j.status,
-                    previous_status=previous_status,
-                    scheduler_id=scheduler_id,
-                )
+        self.sdkmr.get_kafka_client().send_kafka_message(
+            message=KafkaQueueChange(
+                job_id=str(j.id),
+                new_status=j.status,
+                previous_status=previous_status,
+                scheduler_id=scheduler_id,
             )
+        )
 
     def get_job_params(self, job_id, as_admin=False):
         """

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -9,7 +9,7 @@ import time
 from enum import Enum
 from typing import Optional, Dict, NamedTuple, Union, List
 
-from lib.execution_engine2.db.models.models import (
+from execution_engine2.db.models.models import (
     Job,
     JobInput,
     Meta,

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -117,8 +117,10 @@ class EE2RunJob:
 
         self.logger.debug(f"Getting commit for {module_name} {service_ver}")
 
-        module_version = self.sdkmr.get_catalog_utils().get_catalog().get_module_version(
-            {"module_name": module_name, "version": service_ver}
+        module_version = (
+            self.sdkmr.get_catalog_utils()
+            .get_catalog()
+            .get_module_version({"module_name": module_name, "version": service_ver})
         )
 
         git_commit_hash = module_version.get("git_commit_hash")
@@ -193,7 +195,9 @@ class EE2RunJob:
         self._check_ws_objects(source_objects=params.get("source_ws_objects"))
         method = params.get("method")
         # Normalize multiple formats into one format (csv vs json)
-        normalized_resources = self.sdkmr.get_catalog_utils().get_normalized_resources(method)
+        normalized_resources = self.sdkmr.get_catalog_utils().get_normalized_resources(
+            method
+        )
         # These are for saving into job inputs. Maybe its best to pass this into condor as well?
         extracted_resources = self.sdkmr.get_condor().extract_resources(
             cgrr=normalized_resources

--- a/lib/execution_engine2/sdk/SDKMethodRunner.py
+++ b/lib/execution_engine2/sdk/SDKMethodRunner.py
@@ -148,7 +148,7 @@ class SDKMethodRunner:
     # that instance variables cannot be detected by create_autospec with spec_set=True, and thus
     # cannot be mocked in a rigorous way. The danger of not using spec_set=True is that if a
     # mocked class's API changes, the unit tests will still pass. Thus the choice is between
-    # unpythonic getters or false positives in unit tests, and we choose the latter.
+    # unpythonic getters or false positives in unit tests, and we choose the former.
     # For more details: https://www.seanh.cc/2017/03/17/the-problem-with-mocks/
 
     def get_workspace(self) -> Workspace:

--- a/lib/execution_engine2/sdk/SDKMethodRunner.py
+++ b/lib/execution_engine2/sdk/SDKMethodRunner.py
@@ -12,6 +12,7 @@ import os
 import time
 from datetime import datetime
 from enum import Enum
+from logging import Logger
 
 import dateutil
 
@@ -34,6 +35,7 @@ from lib.execution_engine2.utils.KafkaUtils import KafkaClient
 from lib.execution_engine2.utils.SlackUtils import SlackClient
 from execution_engine2.utils.clients import UserClientSet
 from execution_engine2.utils.arg_processing import parse_bool
+from installed_clients.WorkspaceClient import Workspace
 
 
 class JobPermissions(Enum):
@@ -140,6 +142,62 @@ class SDKMethodRunner:
             self.condor = Condor(self.deployment_config_fp)
         return self.condor
 
+    # A note on getters:
+    # Getters are commonly described as unpythonic. However, accessing instance variables
+    # directly, rather than via getters, causes significant problems when mocking a class in
+    # that instance variables cannot be detected by create_autospec with spec_set=True, and thus
+    # cannot be mocked in a rigorous way. The danger of not using spec_set=True is that if a
+    # mocked class's API changes, the unit tests will still pass. Thus the choice is between
+    # unpythonic getters or false positives in unit tests, and we choose the latter.
+    # For more details: https://www.seanh.cc/2017/03/17/the-problem-with-mocks/
+
+    def get_workspace(self) -> Workspace:
+        """
+        Get the workspace client for this instance of SDKMR.
+        """
+        return self.workspace
+
+    def get_logger(self) -> Logger:
+        """
+        Get the logger for this instance of SDKMR.
+        """
+        # There's not really any way to meaningfully test this method without passing in the
+        # logger, which seems... overkill?
+        return self.logger
+
+    def get_catalog_utils(self) -> CatalogUtils:
+        """
+        Get the catalog utilities for this instance of SDKMR.
+        """
+        # TODO Unit test this method once catalog_utils can be mocked.
+        return self.catalog_utils
+
+    def get_kafka_client(self) -> KafkaClient:
+        """
+        Get the Kafka client for this instance of SDKMR.
+        """
+        # TODO Unit test this method once kafka_client can be mocked.
+        return self.kafka_client
+
+    def get_slack_client(self) -> SlackClient:
+        """
+        Get the Kafka client for this instance of SDKMR.
+        """
+        # TODO Unit test this method once slack_client can be mocked.
+        return self.slack_client
+
+    def get_user_id(self) -> str:
+        """
+        Get the user id of the user for this instance of SDKMR.
+        """
+        return self.user_id
+
+    def get_token(self) -> str:
+        """
+        Get the token of the user for this instance of SDKMR.
+        """
+        return self.token
+
     # Permissions Decorators    #TODO Verify these actually work     #TODO add as_admin to these
 
     def allow_job_read(func):
@@ -174,6 +232,14 @@ class SDKMethodRunner:
             raise AuthError(
                 "You are not the concierge user. This method is not for you"
             )
+
+    def save_job(self, job: Job):
+        """
+        Save a job record to the Mongo database.
+        """
+        # The purpose of this method is to allow unit testing the various EE2*.py classes.
+        job.save()
+        return str(job.id)
 
     # API ENDPOINTS
 

--- a/lib/execution_engine2/sdk/SDKMethodRunner.py
+++ b/lib/execution_engine2/sdk/SDKMethodRunner.py
@@ -18,7 +18,7 @@ import dateutil
 
 from installed_clients.authclient import KBaseAuth
 from lib.execution_engine2.db.MongoUtil import MongoUtil
-from lib.execution_engine2.db.models.models import Job
+from execution_engine2.db.models.models import Job
 from lib.execution_engine2.exceptions import AuthError
 from lib.execution_engine2.sdk import (
     EE2Runjob,

--- a/lib/execution_engine2/utils/CatalogUtils.py
+++ b/lib/execution_engine2/utils/CatalogUtils.py
@@ -8,6 +8,11 @@ class CatalogUtils:
     def __init__(self, url, admin_token):
         self.catalog = Catalog(url=url, token=admin_token)
 
+    def get_catalog(self):
+        """ Get the catalog client for this instance. """
+        # TODO unit test this method after switching to dependency injection
+        return self.catalog
+
     def get_normalized_resources(self, method) -> Dict:
         """
         get client groups info from Catalog

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -203,34 +203,60 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
     # so we can't do a straight equality
     assert abs(got_job.updated - expected_job.updated) < 1
 
-    job_fields = ['user', 'authstrat', 'wsid', 'status', 'queued', 'estimating', 'running',
-                  'finished', 'errormsg', 'msg', 'error', 'terminated_code', 'error_code',
-                  'scheduler_type', 'scheduler_id', 'scheduler_estimator_id', 'job_output',
-                  'condor_job_ads', 'child_jobs', 'batch_job']
+    job_fields = [
+        "user",
+        "authstrat",
+        "wsid",
+        "status",
+        "queued",
+        "estimating",
+        "running",
+        "finished",
+        "errormsg",
+        "msg",
+        "error",
+        "terminated_code",
+        "error_code",
+        "scheduler_type",
+        "scheduler_id",
+        "scheduler_estimator_id",
+        "job_output",
+        "condor_job_ads",
+        "child_jobs",
+        "batch_job",
+    ]
 
     _super_hacky_equals(got_job, expected_job, job_fields)
 
     if not got_job.job_input:
         assert expected_job.job_input is None
     else:
-        job_input_fields = ['wsid', 'method', 'requested_release', 'params', 'service_ver',
-                            'app_id', 'source_ws_objects', 'parent_job_id']
+        job_input_fields = [
+            "wsid",
+            "method",
+            "requested_release",
+            "params",
+            "service_ver",
+            "app_id",
+            "source_ws_objects",
+            "parent_job_id",
+        ]
         _super_hacky_equals(got_job.job_input, expected_job.job_input, job_input_fields)
 
-        requirements_fields = ['clientgroup', 'cpu', 'memory', 'disk', 'estimate']
+        requirements_fields = ["clientgroup", "cpu", "memory", "disk", "estimate"]
         _super_hacky_equals(
             got_job.job_input.requirements,
             expected_job.job_input.requirements,
-            requirements_fields
+            requirements_fields,
         )
         # this fails, which should be impossible given all the fields above pass
         # assert got_job.job_input.requirements == expected_job.job_input.requirements
 
-        cell_info_fields = ['run_id', 'token_id', 'tag', 'cell_id', 'status']
+        cell_info_fields = ["run_id", "token_id", "tag", "cell_id", "status"]
         _super_hacky_equals(
             got_job.job_input.narrative_cell_info,
             expected_job.job_input.narrative_cell_info,
-            cell_info_fields
+            cell_info_fields,
         )
         # again, this fails, even though the fields are all ==
         # assert got_job.job_input.narrative_cell_info == (

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -4,6 +4,7 @@ Unit tests for the EE2Runjob class.
 
 # Incomplete by a long way. Will add more unit tests as they come up.
 
+from typing import List
 from bson.objectid import ObjectId
 from logging import Logger
 from unittest.mock import create_autospec
@@ -226,7 +227,7 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
         "batch_job",
     ]
 
-    _super_hacky_equals(got_job, expected_job, job_fields)
+    _assert_field_subset_equal(got_job, expected_job, job_fields)
 
     if not got_job.job_input:
         assert expected_job.job_input is None
@@ -241,10 +242,12 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
             "source_ws_objects",
             "parent_job_id",
         ]
-        _super_hacky_equals(got_job.job_input, expected_job.job_input, job_input_fields)
+        _assert_field_subset_equal(
+            got_job.job_input, expected_job.job_input, job_input_fields
+        )
 
         requirements_fields = ["clientgroup", "cpu", "memory", "disk", "estimate"]
-        _super_hacky_equals(
+        _assert_field_subset_equal(
             got_job.job_input.requirements,
             expected_job.job_input.requirements,
             requirements_fields,
@@ -253,7 +256,7 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
         # assert got_job.job_input.requirements == expected_job.job_input.requirements
 
         cell_info_fields = ["run_id", "token_id", "tag", "cell_id", "status"]
-        _super_hacky_equals(
+        _assert_field_subset_equal(
             got_job.job_input.narrative_cell_info,
             expected_job.job_input.narrative_cell_info,
             cell_info_fields,
@@ -263,7 +266,15 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
         #     expected_job.job_input.narrative_cell_info)
 
 
-def _super_hacky_equals(obj1, obj2, fields):
+def _assert_field_subset_equal(obj1: object, obj2: object, fields: List[str]):
+    """
+    Checks that field subsets from two objects are the same.
+
+    :param obj1: The first object
+    :param obj2: The second object
+    :param fields: The fields in the objects to compare for equality. Any fields in the object
+        not in this list are ignored and not included in the equality calculation.
+    :raises AttributeError: If the field is not present in one or both of the objects.
+    """
     for field in fields:
-        # An AttributeError will be raised if the field is not present in the object
         assert getattr(obj1, field) == getattr(obj2, field), field

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -124,9 +124,7 @@ def test_run_as_admin():
     got_job = sdkmr.save_job.call_args_list[0][0][0]
     assert_jobs_equal(got_job, expected_job)
 
-    kafka.send_kafka_message.assert_any_call(
-        KafkaCreateJob("someuser", job_id)
-    )
+    kafka.send_kafka_message.assert_any_call(KafkaCreateJob("someuser", job_id))
     condor.run_job.assert_called_once_with(
         params={
             "method": "lolcats.lol_unto_death",
@@ -167,9 +165,7 @@ def test_run_as_admin():
             scheduler_id="cluster42",
         )
     )
-    slack.run_job_message.assert_called_once_with(
-        job_id, "cluster42", "someuser"
-    )
+    slack.run_job_message.assert_called_once_with(job_id, "cluster42", "someuser")
 
 
 def assert_jobs_equal(got_job: Job, expected_job: Job):

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -6,7 +6,7 @@ Unit tests for the EE2Runjob class.
 
 from bson.objectid import ObjectId
 from logging import Logger
-from unittest.mock import create_autospec, call
+from unittest.mock import create_autospec
 from execution_engine2.db.models.models import Job, JobInput, JobRequirements, Meta
 from execution_engine2.sdk.EE2Runjob import EE2RunJob, JobPermissions
 from execution_engine2.sdk.SDKMethodRunner import SDKMethodRunner

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -265,4 +265,5 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
 
 def _super_hacky_equals(obj1, obj2, fields):
     for field in fields:
+        # An AttributeError will be raised if the field is not present in the object
         assert getattr(obj1, field) == getattr(obj2, field), field

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -22,7 +22,7 @@ from execution_engine2.utils.KafkaUtils import (
     KafkaCreateJob,
 )
 from execution_engine2.utils.SlackUtils import SlackClient
-from lib.execution_engine2.db.MongoUtil import MongoUtil
+from execution_engine2.db.MongoUtil import MongoUtil
 from installed_clients.WorkspaceClient import Workspace
 from installed_clients.CatalogClient import Catalog
 

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -134,7 +134,7 @@ def test_run_as_admin():
     jr.disk = "2600"
     ji.requirements = jr
     ji.narrative_cell_info = Meta()
-    expected_job.job_input = ji
+    expected_job.job_input = ji 
     assert len(sdkmr.save_job.call_args_list) == 2
     got_job = sdkmr.save_job.call_args_list[0][0][0]
     assert_jobs_equal(got_job, expected_job)
@@ -188,9 +188,15 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
     Checks that the two jobs are equivalent, except that the 'updated' fields are checked that
     they're within 1 second of each other.
     """
-    # I could not get assert got_job == expected_job to ever work when their fields were identical.
-    # Also accessing the instance dict via vars() or __dict__ only produced {'_cls': 'Job'} so
-    # apparently MongoEngine does something very odd with the dict.
+    # Job inherits from Document which inherits from BaseDocument in MongoEngine. BD provides
+    # the __eq__ method for the hierarchy, which bases equality on the Jobs having equal id
+    # fields, or if no id is present, on identity. Therefore
+    # assert job1 == job2
+    # will not work as a test mechanic.
+    # JobInput and its contained classes inherit from EmbeddedDocument which *does* have an
+    # __eq__ method that takes the class fields into account.
+    # Also note that all these classes use __slots__ so vars() and __dict__ are empty other
+    # than the class name.
     # Hence we do this disgusting hack instead. Note it will need to be updated any time a
     # job field is added.
 
@@ -217,10 +223,10 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
         "error",
         "terminated_code",
         "error_code",
-        "job_input",
         "scheduler_type",
         "scheduler_id",
         "scheduler_estimator_id",
+        "job_input",
         "job_output",
         "condor_job_ads",
         "child_jobs",

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -134,7 +134,7 @@ def test_run_as_admin():
     jr.disk = "2600"
     ji.requirements = jr
     ji.narrative_cell_info = Meta()
-    expected_job.job_input = ji 
+    expected_job.job_input = ji
     assert len(sdkmr.save_job.call_args_list) == 2
     got_job = sdkmr.save_job.call_args_list[0][0][0]
     assert_jobs_equal(got_job, expected_job)

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -1,0 +1,233 @@
+"""
+Unit tests for the EE2Runjob class.
+"""
+
+# Incomplete by a long way. Will add more unit tests as they come up.
+
+from bson.objectid import ObjectId
+from logging import Logger
+from unittest.mock import create_autospec, call
+from execution_engine2.db.models.models import Job, JobInput, JobRequirements, Meta
+from execution_engine2.sdk.EE2Runjob import EE2RunJob, JobPermissions
+from execution_engine2.sdk.SDKMethodRunner import SDKMethodRunner
+from execution_engine2.utils.CatalogUtils import CatalogUtils
+from execution_engine2.utils.Condor import (
+    Condor,
+    CondorResources,
+    SubmissionInfo,
+)
+from execution_engine2.utils.KafkaUtils import KafkaClient, KafkaQueueChange, KafkaCreateJob
+from execution_engine2.utils.SlackUtils import SlackClient
+from lib.execution_engine2.db.MongoUtil import MongoUtil
+from installed_clients.WorkspaceClient import Workspace
+from installed_clients.CatalogClient import Catalog
+
+
+def test_run_as_admin():
+    """
+    A basic unit test of the run() method with an administrative user.
+
+    This test is a fairly minimal test of the run() method. It does not exercise all the
+    potential code paths or provide all the possible run inputs, such as job parameters, cell
+    metadata, etc.
+    """
+    # The amount of mocking required here implies the method should be broken up into smaller
+    # classes that are individually mockable. Or maybe it's just really complicated and this
+    # is the best we can do. Worth looking into at some point though.
+
+    # We intentionally do not check the logger methods as there are a lot of them and this is
+    # already a very large test. This may be something to be added later when needed.
+    sdkmr = create_autospec(SDKMethodRunner, spec_set=True, instance=True)
+    logger = create_autospec(Logger, spec_set=True, instance=True)
+    ws = create_autospec(Workspace, spec_set=True, instance=True)
+    catutils = create_autospec(CatalogUtils, spec_set=True, instance=True)
+    catalog = create_autospec(Catalog, spec_set=True, instance=True)
+    condor = create_autospec(Condor, spec_set=True, instance=True)
+    kafka = create_autospec(KafkaClient, spec_set=True, instance=True)
+    mongo = create_autospec(MongoUtil, spec_set=True, instance=True)
+    slack = create_autospec(SlackClient, spec_set=True, instance=True)
+    sdkmr.get_logger.return_value = logger
+    sdkmr.get_workspace.return_value = ws
+    sdkmr.get_catalog_utils.return_value = catutils
+    catutils.get_catalog.return_value = catalog
+    sdkmr.get_condor.return_value = condor
+    sdkmr.get_kafka_client.return_value = kafka
+    sdkmr.get_slack_client.return_value = slack
+    sdkmr.get_mongo_util.return_value = mongo
+    sdkmr.get_user_id.return_value = 'someuser'
+    sdkmr.get_token.return_value = 'tokentokentoken'
+    sdkmr.check_as_admin.return_value = True
+    sdkmr.save_job.return_value = '603051cfaf2e3401b0500982'
+    ws.get_object_info3.return_value = {'paths': [['1/2/3'], ['4/5/6']]}
+    catalog_resources = {
+        'client_group': 'grotesquememlong',
+        'request_cpus': '4',
+        "request_memory": "32"}
+    catutils.get_normalized_resources.return_value = catalog_resources
+    condor.extract_resources.return_value = CondorResources("4", "2600", "32", "grotesquememlong")
+    catalog.get_module_version.return_value = {'git_commit_hash': 'git5678'}
+    condor.run_job.return_value = SubmissionInfo("cluster42", {}, None)
+    retjob = Job()
+    retjob.id = ObjectId("603051cfaf2e3401b0500982")
+    retjob.status = "created"
+    mongo.get_job.return_value = retjob
+
+    # set up the class to be tested and run the method
+    rj = EE2RunJob(sdkmr)
+    params = {
+        'method': 'lolcats.lol_unto_death',
+        'source_ws_objects': ['1/2/3', '4/5/6'],
+    }
+    assert rj.run(params, as_admin=True) == "603051cfaf2e3401b0500982"
+
+    # check mocks called as expected
+    sdkmr.check_as_admin.assert_called_once_with(JobPermissions.WRITE)
+    ws.get_object_info3.assert_called_once_with({
+        'objects': [{'ref': '1/2/3'}, {'ref': '4/5/6'}],
+        'ignoreErrors': 1
+    })
+    catutils.get_normalized_resources.assert_called_once_with('lolcats.lol_unto_death')
+    condor.extract_resources.assert_called_once_with(catalog_resources)
+    catalog.get_module_version.assert_called_once_with(
+        {'module_name': 'lolcats', 'version': 'release'})
+
+    # initial job data save
+    expected_job = Job()
+    expected_job.user = 'someuser'
+    expected_job.status = 'created'
+    ji = JobInput()
+    ji.method = "lolcats.lol_unto_death"
+    ji.service_ver = "git5678"
+    ji.source_ws_objects = ["1/2/3", "4/5/6"]
+    ji.parent_job_id = "None"
+    jr = JobRequirements()
+    jr.clientgroup = "grotesquememlong"
+    jr.cpu = "4"
+    jr.memory = "3"
+    jr.disk = "26"
+    ji.requirements = jr
+    ji.narrative_cell_info = Meta()
+    expected_job.job_input = ji
+    assert len(sdkmr.save_job.call_args_list) == 2
+    got_job = sdkmr.save_job.call_args_list[0][0][0]
+    assert_jobs_equal(got_job, expected_job)
+
+    kafka.send_kafka_message.assert_any_call(KafkaCreateJob(
+        'someuser', '603051cfaf2e3401b0500982'))
+    condor.run_job.assert_called_once_with(
+        params={'method': 'lolcats.lol_unto_death',
+                'source_ws_objects': ['1/2/3', '4/5/6'],
+                'service_ver': 'git5678',
+                'job_id': '603051cfaf2e3401b0500982',
+                'user_id': 'someuser',
+                'token': 'tokentokentoken',
+                'cg_resources_requirements': {
+                    'client_group': 'grotesquememlong',
+                    'request_cpus': '4',
+                    'request_memory': '32'}
+                },
+        concierge_params=None
+    )
+
+    # updated job data save
+    mongo.get_job.assert_called_once_with("603051cfaf2e3401b0500982")
+
+    # update to queued stat
+    got_job = sdkmr.save_job.call_args_list[1][0][0]
+    expected_job = Job()
+    expected_job.id = ObjectId("603051cfaf2e3401b0500982")
+    expected_job.status = "queued"
+    expected_job.queued = got_job.queued  # no way to test this really without code refactoring
+    expected_job.scheduler_type = "condor"
+    expected_job.scheduler_id = "cluster42"
+    assert_jobs_equal(got_job, expected_job)
+
+    kafka.send_kafka_message.assert_called_with(  # update to queued state
+        KafkaQueueChange(
+            job_id="603051cfaf2e3401b0500982",
+            new_status="queued",
+            previous_status="created",
+            scheduler_id="cluster42",
+        )
+    )
+    slack.run_job_message.assert_called_once_with(
+        "603051cfaf2e3401b0500982", "cluster42", "someuser")
+
+
+def assert_jobs_equal(got_job: Job, expected_job: Job):
+    """
+    Checks that the two jobs are equivalent, except that the 'updated' fields are checked that
+    they're within 1 second of each other.
+    """
+    # I could not get assert got_job == expected_job to ever work, or even
+    # JobRequirements1 == JobRequirements2 to work when their fields were identical, so we
+    # do this disgusting hack instead. Note it will need to be updated any time a job field is
+    # added.
+    if not hasattr(got_job, 'id'):
+        assert not hasattr(expected_job, 'id')
+    else:
+        assert got_job.id == expected_job.id
+    assert got_job.user == expected_job.user
+    assert got_job.authstrat == expected_job.authstrat
+    assert got_job.wsid == expected_job.wsid
+    assert got_job.status == expected_job.status
+
+    # The Job class fills the updated field with the output of time.time on instantiation
+    # so we can't do a straight equality
+    assert abs(got_job.updated - expected_job.updated) < 1
+
+    assert got_job.queued == expected_job.queued
+    assert got_job.estimating == expected_job.estimating
+    assert got_job.running == expected_job.running
+    assert got_job.finished == expected_job.finished
+    assert got_job.errormsg == expected_job.errormsg
+    assert got_job.msg == expected_job.msg
+    assert got_job.error == expected_job.error
+    assert got_job.terminated_code == expected_job.terminated_code
+    assert got_job.error_code == expected_job.error_code
+    assert got_job.scheduler_type == expected_job.scheduler_type
+    assert got_job.scheduler_id == expected_job.scheduler_id
+    assert got_job.scheduler_estimator_id == expected_job.scheduler_estimator_id
+
+    if not got_job.job_input:
+        assert expected_job.job_input is None
+    else:
+        assert got_job.job_input.wsid == expected_job.job_input.wsid
+        assert got_job.job_input.method == expected_job.job_input.method
+        assert got_job.job_input.requested_release == expected_job.job_input.requested_release
+        assert got_job.job_input.params == expected_job.job_input.params
+        assert got_job.job_input.service_ver == expected_job.job_input.service_ver
+        assert got_job.job_input.app_id == expected_job.job_input.app_id
+        assert got_job.job_input.source_ws_objects == expected_job.job_input.source_ws_objects
+        assert got_job.job_input.parent_job_id == expected_job.job_input.parent_job_id
+
+        assert got_job.job_input.requirements.clientgroup == (
+            expected_job.job_input.requirements.clientgroup)
+        assert got_job.job_input.requirements.cpu == expected_job.job_input.requirements.cpu
+        assert got_job.job_input.requirements.memory == expected_job.job_input.requirements.memory
+        assert got_job.job_input.requirements.disk == expected_job.job_input.requirements.disk
+        assert got_job.job_input.requirements.estimate == (
+            expected_job.job_input.requirements.estimate)
+
+        # this fails, which should be impossible given all the fields above pass
+        # assert got_job.job_input.requirements == expected_job.job_input.requirements
+
+        assert got_job.job_input.narrative_cell_info.run_id == (
+            expected_job.job_input.narrative_cell_info.run_id)
+        assert got_job.job_input.narrative_cell_info.token_id == (
+            expected_job.job_input.narrative_cell_info.token_id)
+        assert got_job.job_input.narrative_cell_info.tag == (
+            expected_job.job_input.narrative_cell_info.tag)
+        assert got_job.job_input.narrative_cell_info.cell_id == (
+            expected_job.job_input.narrative_cell_info.cell_id)
+        assert got_job.job_input.narrative_cell_info.status == (
+            expected_job.job_input.narrative_cell_info.status)
+
+        # again, this fails, even though the fields are all ==
+        # assert got_job.job_input.narrative_cell_info == (
+        #     expected_job.job_input.narrative_cell_info)
+
+    assert got_job.job_output == expected_job.job_output
+    assert got_job.condor_job_ads == expected_job.condor_job_ads
+    assert got_job.child_jobs == expected_job.child_jobs
+    assert got_job.batch_job == expected_job.batch_job

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -188,8 +188,7 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
     Checks that the two jobs are equivalent, except that the 'updated' fields are checked that
     they're within 1 second of each other.
     """
-    # I could not get assert got_job == expected_job to ever work, or even
-    # JobRequirements1 == JobRequirements2 to work when their fields were identical.
+    # I could not get assert got_job == expected_job to ever work when their fields were identical.
     # Also accessing the instance dict via vars() or __dict__ only produced {'_cls': 'Job'} so
     # apparently MongoEngine does something very odd with the dict.
     # Hence we do this disgusting hack instead. Note it will need to be updated any time a
@@ -218,6 +217,7 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
         "error",
         "terminated_code",
         "error_code",
+        "job_input",
         "scheduler_type",
         "scheduler_id",
         "scheduler_estimator_id",
@@ -228,42 +228,6 @@ def assert_jobs_equal(got_job: Job, expected_job: Job):
     ]
 
     _assert_field_subset_equal(got_job, expected_job, job_fields)
-
-    if not got_job.job_input:
-        assert expected_job.job_input is None
-    else:
-        job_input_fields = [
-            "wsid",
-            "method",
-            "requested_release",
-            "params",
-            "service_ver",
-            "app_id",
-            "source_ws_objects",
-            "parent_job_id",
-        ]
-        _assert_field_subset_equal(
-            got_job.job_input, expected_job.job_input, job_input_fields
-        )
-
-        requirements_fields = ["clientgroup", "cpu", "memory", "disk", "estimate"]
-        _assert_field_subset_equal(
-            got_job.job_input.requirements,
-            expected_job.job_input.requirements,
-            requirements_fields,
-        )
-        # this fails, which should be impossible given all the fields above pass
-        # assert got_job.job_input.requirements == expected_job.job_input.requirements
-
-        cell_info_fields = ["run_id", "token_id", "tag", "cell_id", "status"]
-        _assert_field_subset_equal(
-            got_job.job_input.narrative_cell_info,
-            expected_job.job_input.narrative_cell_info,
-            cell_info_fields,
-        )
-        # again, this fails, even though the fields are all ==
-        # assert got_job.job_input.narrative_cell_info == (
-        #     expected_job.job_input.narrative_cell_info)
 
 
 def _assert_field_subset_equal(obj1: object, obj2: object, fields: List[str]):

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -64,7 +64,7 @@ def test_run_as_admin():
 
     job_id = "603051cfaf2e3401b0500982"
 
-    # Set up call returns. These calls are in the order the occur in the code
+    # Set up call returns. These calls are in the order they occur in the code
     sdkmr.check_as_admin.return_value = True
     sdkmr.save_job.return_value = job_id
     ws.get_object_info3.return_value = {"paths": [["1/2/3"], ["4/5/6"]]}

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -160,11 +160,10 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         # For a discussion of spec_set see
         # https://www.seanh.cc/2017/03/17/the-problem-with-mocks/
         j = create_autospec(Job, spec_set=False, instance=True)
-        j.id = bson.objectid.ObjectId('603051cfaf2e3401b0500982')
-        assert sdkmr.save_job(j) == '603051cfaf2e3401b0500982'
+        j.id = bson.objectid.ObjectId("603051cfaf2e3401b0500982")
+        assert sdkmr.save_job(j) == "603051cfaf2e3401b0500982"
 
         j.save.assert_called_once_with()
-
 
     # Status
     @patch("lib.execution_engine2.utils.Condor.Condor", autospec=True)

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -8,7 +8,7 @@ import unittest
 from configparser import ConfigParser
 from datetime import datetime, timedelta, timezone
 from pprint import pprint
-from unittest.mock import patch
+from unittest.mock import patch, create_autospec
 from pytest import raises
 
 import bson
@@ -17,12 +17,14 @@ import requests_mock
 from bson import ObjectId
 from mock import MagicMock
 
+from execution_engine2.authorization.workspaceauth import WorkspaceAuth
 from lib.execution_engine2.db.MongoUtil import MongoUtil
 from lib.execution_engine2.db.models.models import Job, Status, TerminatedCode
 from lib.execution_engine2.exceptions import AuthError
 from lib.execution_engine2.exceptions import InvalidStatusTransitionException
 from lib.execution_engine2.sdk.SDKMethodRunner import SDKMethodRunner
 from lib.execution_engine2.utils.CondorTuples import SubmissionInfo, CondorResources
+from execution_engine2.utils.clients import UserClientSet
 from execution_engine2.utils.clients import get_user_client_set
 from test.tests_for_sdkmr.ee2_SDKMethodRunner_test_utils import ee2_sdkmr_test_helper
 from test.utils_shared.test_utils import (
@@ -38,6 +40,8 @@ logging.basicConfig(level=logging.INFO)
 bootstrap()
 
 from lib.execution_engine2.sdk.EE2Runjob import EE2RunJob
+
+from installed_clients.WorkspaceClient import Workspace
 
 
 # TODO this isn't necessary with pytest, can just use regular old functions
@@ -132,6 +136,35 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         with raises(Exception) as e:
             SDKMethodRunner(cfg, user_clients)
         assert_exception_correct(e.value, expected)
+
+    def test_getters(self):
+        ws = Workspace("https://fake.com")
+        wsa = WorkspaceAuth("user", ws)
+        cliset = UserClientSet("user", "token", ws, wsa)
+        sdkmr = SDKMethodRunner(self.cfg, cliset)
+
+        assert sdkmr.get_workspace() is ws
+        assert sdkmr.get_user_id() == "user"
+        assert sdkmr.get_token() == "token"
+
+    def test_save_job(self):
+        ws = Workspace("https://fake.com")
+        wsa = WorkspaceAuth("user", ws)
+        cliset = UserClientSet("user", "token", ws, wsa)
+        sdkmr = SDKMethodRunner(self.cfg, cliset)
+
+        # We cannot use spec_set=True here because the code must access the Job.id field,
+        # which is set dynamically. This means if the Job api changes, this test could pass
+        # when it should fail, but there doesn't seem to be a way around that other than
+        # completely rewriting how the code interfaces with MongoDB.
+        # For a discussion of spec_set see
+        # https://www.seanh.cc/2017/03/17/the-problem-with-mocks/
+        j = create_autospec(Job, spec_set=False, instance=True)
+        j.id = bson.objectid.ObjectId('603051cfaf2e3401b0500982')
+        assert sdkmr.save_job(j) == '603051cfaf2e3401b0500982'
+
+        j.save.assert_called_once_with()
+
 
     # Status
     @patch("lib.execution_engine2.utils.Condor.Condor", autospec=True)


### PR DESCRIPTION
# Description of PR purpose/changes

Fixes a bug where a SDKMR.get_workspace() method was expected but was removed in a
previous PR.

Creates a unit test for the run() method where the bug occurred.

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - over 3k warnings currently
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
