### PR TITLE
Fix date range job search bug

### DIFF
--- a/lib/execution_engine2/sdk/EE2StatusRange.py
+++ b/lib/execution_engine2/sdk/EE2StatusRange.py
@@ -7,7 +7,7 @@ from typing import Dict
 from bson import ObjectId
 
 from execution_engine2.utils.arg_processing import parse_bool
-from lib.execution_engine2.exceptions import AuthError
+from execution_engine2.exceptions import AuthError
 
 
 # TODO this class is duplicated all over the place, move to common file
@@ -78,11 +78,11 @@ class JobStatusRange:
         if user is None:
             user = self.sdkmr.get_user_id()
         # Admins can view "ALL" or check_jobs for other users
-        if user != self.sdkmr.get_user_id():
+        elif user != self.sdkmr.get_user_id():
             if not self.sdkmr.check_is_admin():
                 raise AuthError(
                     "You are not authorized to view all records or records for others. "
-                    + f"user={user} token={self.sdkmr.user_id}"
+                    + f"user={user} token={self.sdkmr.get_user_id()}"
                 )
 
         dummy_ids = self._get_dummy_dates(creation_start_time, creation_end_time)

--- a/lib/execution_engine2/sdk/EE2StatusRange.py
+++ b/lib/execution_engine2/sdk/EE2StatusRange.py
@@ -7,7 +7,6 @@ from typing import Dict
 from bson import ObjectId
 
 from execution_engine2.utils.arg_processing import parse_bool
-from lib.execution_engine2.db.models.models import Job
 from lib.execution_engine2.exceptions import AuthError
 
 

--- a/lib/execution_engine2/sdk/EE2StatusRange.py
+++ b/lib/execution_engine2/sdk/EE2StatusRange.py
@@ -120,7 +120,9 @@ class JobStatusRange:
             job_filter_temp["user"] = user
 
         count = self.sdkmr.get_job_counts(job_filter_temp)
-        jobs = self.sdkmr.get_jobs(job_filter_temp, job_projection, sort_order, offset, limit)
+        jobs = self.sdkmr.get_jobs(
+            job_filter_temp, job_projection, sort_order, offset, limit
+        )
 
         self.sdkmr.get_logger().debug(
             f"Searching for jobs with id_gt {dummy_ids.start} id_lt {dummy_ids.stop}"

--- a/test/tests_for_sdkmr/EE2StatusRange_test.py
+++ b/test/tests_for_sdkmr/EE2StatusRange_test.py
@@ -61,41 +61,49 @@ def _run_minimal(user):
     ret = ee2sr.check_jobs_date_range_for_user("5/6/21", "7/6/21", user=user)
 
     assert ret == {
-        'count': 1,
-        'filter': {'id__gt': '000000230000000000000000',
-                   'id__lt': '0000005c0000000000000000',
-                   'user': expected_user},
-        'jobs': [{'_id': objectid,
-                  'authstrat': 'kbaseworkspace',
-                  'batch_job': False,
-                  'child_jobs': [],
-                  'created': 1613779407000,
-                  'job_id': objectid,
-                  'status': created_state,
-                  'updated': 1000000000,
-                  'user': expected_user}],
-        'limit': 2000,
-        'projection': [],
-        'query_count': job_count,
-        'skip': 0,
-        'sort_order': '+',
-        'stats': {'app_id': {None: 1},
-                  'clientgroup': {None: 1},
-                  'method': {None: 1},
-                  'status': {created_state: 1},
-                  'user': {expected_user: 1},
-                  'wsid': {None: 1}
-                  }
+        "count": 1,
+        "filter": {
+            "id__gt": "000000230000000000000000",
+            "id__lt": "0000005c0000000000000000",
+            "user": expected_user,
+        },
+        "jobs": [
+            {
+                "_id": objectid,
+                "authstrat": "kbaseworkspace",
+                "batch_job": False,
+                "child_jobs": [],
+                "created": 1613779407000,
+                "job_id": objectid,
+                "status": created_state,
+                "updated": 1000000000,
+                "user": expected_user,
+            }
+        ],
+        "limit": 2000,
+        "projection": [],
+        "query_count": job_count,
+        "skip": 0,
+        "sort_order": "+",
+        "stats": {
+            "app_id": {None: 1},
+            "clientgroup": {None: 1},
+            "method": {None: 1},
+            "status": {created_state: 1},
+            "user": {expected_user: 1},
+            "wsid": {None: 1},
+        },
     }
 
     # check mocks called as expected. Ordered as per the call order in the EE2SR code
     sdkmr.check_and_convert_time.assert_has_calls([call("5/6/21"), call("7/6/21")])
     expected_job_filter = {
-        'id__gt': '000000230000000000000000',
-        'id__lt': '0000005c0000000000000000',
-        'user': expected_user
+        "id__gt": "000000230000000000000000",
+        "id__lt": "0000005c0000000000000000",
+        "user": expected_user,
     }
     sdkmr.get_job_counts.assert_called_once_with(expected_job_filter)
-    sdkmr.get_jobs.assert_called_once_with(expected_job_filter, [], '+', 0, 2000)
+    sdkmr.get_jobs.assert_called_once_with(expected_job_filter, [], "+", 0, 2000)
     logger.debug.assert_called_once_with(
-        'Searching for jobs with id_gt 000000230000000000000000 id_lt 0000005c0000000000000000')
+        "Searching for jobs with id_gt 000000230000000000000000 id_lt 0000005c0000000000000000"
+    )

--- a/test/tests_for_sdkmr/EE2StatusRange_test.py
+++ b/test/tests_for_sdkmr/EE2StatusRange_test.py
@@ -8,7 +8,7 @@ from bson.objectid import ObjectId
 
 from execution_engine2.sdk.SDKMethodRunner import SDKMethodRunner
 from execution_engine2.sdk.EE2StatusRange import JobStatusRange
-from execution_engine2.db.models.models import Job, JobInput, JobRequirements, Meta
+from execution_engine2.db.models.models import Job
 
 
 # Incomplete by a long way. Will add more unit tests as they come up.

--- a/test/tests_for_sdkmr/EE2StatusRange_test.py
+++ b/test/tests_for_sdkmr/EE2StatusRange_test.py
@@ -2,14 +2,18 @@
 Unit tests for the EE2StatusRange class.
 """
 
+from pytest import raises
+
 from logging import Logger
 from unittest.mock import create_autospec, call
 from bson.objectid import ObjectId
 
+from execution_engine2.exceptions import AuthError
 from execution_engine2.sdk.SDKMethodRunner import SDKMethodRunner
 from execution_engine2.sdk.EE2StatusRange import JobStatusRange
 from execution_engine2.db.models.models import Job
 
+from utils_shared.test_utils import assert_exception_correct
 
 # Incomplete by a long way. Will add more unit tests as they come up.
 
@@ -40,6 +44,11 @@ def _run_minimal(user):
     job_count = 26
     objectid = "603051cfaf2e3401b0500982"
     created_state = "created"
+    expected_job_filter = {
+        "id__gt": "000000230000000000000000",
+        "id__lt": "0000005c0000000000000000",
+        "user": expected_user,
+    }
 
     # set up mock return values. Ordered as per the call order in the EE2SR code.
     sdkmr = create_autospec(SDKMethodRunner, spec_set=True, instance=True)
@@ -62,17 +71,14 @@ def _run_minimal(user):
 
     assert ret == {
         "count": 1,
-        "filter": {
-            "id__gt": "000000230000000000000000",
-            "id__lt": "0000005c0000000000000000",
-            "user": expected_user,
-        },
+        "filter": expected_job_filter,
         "jobs": [
             {
                 "_id": objectid,
                 "authstrat": "kbaseworkspace",
                 "batch_job": False,
                 "child_jobs": [],
+                # this comes from the ObjectID, which has an embedded date
                 "created": 1613779407000,
                 "job_id": objectid,
                 "status": created_state,
@@ -97,13 +103,27 @@ def _run_minimal(user):
 
     # check mocks called as expected. Ordered as per the call order in the EE2SR code
     sdkmr.check_and_convert_time.assert_has_calls([call("5/6/21"), call("7/6/21")])
-    expected_job_filter = {
-        "id__gt": "000000230000000000000000",
-        "id__lt": "0000005c0000000000000000",
-        "user": expected_user,
-    }
     sdkmr.get_job_counts.assert_called_once_with(expected_job_filter)
     sdkmr.get_jobs.assert_called_once_with(expected_job_filter, [], "+", 0, 2000)
     logger.debug.assert_called_once_with(
         "Searching for jobs with id_gt 000000230000000000000000 id_lt 0000005c0000000000000000"
     )
+
+
+def test_run_with_non_matching_user_and_not_admin():
+    """
+    Test that a user trying to see another user's jobs without admin privs fails as expected.
+    """
+    sdkmr = create_autospec(SDKMethodRunner, spec_set=True, instance=True)
+    sdkmr.get_user_id.return_value = "user1"
+    sdkmr.check_is_admin.return_value = False
+
+    ee2sr = JobStatusRange(sdkmr)
+    with raises(Exception) as got:
+        ee2sr.check_jobs_date_range_for_user("5/6/21", "7/6/21", user="user2")
+    assert_exception_correct(got.value, AuthError(
+        "You are not authorized to view all records or records for others. user=user2 token=user1"
+    ))
+
+    sdkmr.get_user_id.assert_has_calls([call(), call()])
+    sdkmr.check_is_admin.assert_called_once_with()

--- a/test/tests_for_sdkmr/EE2StatusRange_test.py
+++ b/test/tests_for_sdkmr/EE2StatusRange_test.py
@@ -121,9 +121,13 @@ def test_run_with_non_matching_user_and_not_admin():
     ee2sr = JobStatusRange(sdkmr)
     with raises(Exception) as got:
         ee2sr.check_jobs_date_range_for_user("5/6/21", "7/6/21", user="user2")
-    assert_exception_correct(got.value, AuthError(
-        "You are not authorized to view all records or records for others. user=user2 token=user1"
-    ))
+    assert_exception_correct(
+        got.value,
+        AuthError(
+            "You are not authorized to view all records or records for others. "
+            + "user=user2 token=user1"
+        ),
+    )
 
     sdkmr.get_user_id.assert_has_calls([call(), call()])
     sdkmr.check_is_admin.assert_called_once_with()

--- a/test/tests_for_sdkmr/EE2StatusRange_test.py
+++ b/test/tests_for_sdkmr/EE2StatusRange_test.py
@@ -1,0 +1,101 @@
+"""
+Unit tests for the EE2StatusRange class.
+"""
+
+from logging import Logger
+from unittest.mock import create_autospec, call
+from bson.objectid import ObjectId
+
+from execution_engine2.sdk.SDKMethodRunner import SDKMethodRunner
+from execution_engine2.sdk.EE2StatusRange import JobStatusRange
+from execution_engine2.db.models.models import Job, JobInput, JobRequirements, Meta
+
+
+# Incomplete by a long way. Will add more unit tests as they come up.
+
+USER1 = "user1"
+
+
+def test_run_minimal_no_user_in_input():
+    """
+    Tests a minimal run of the job lookup method as a standard user with no username passed into
+    the method.
+    The returned job has minimal fields.
+    """
+    _run_minimal(None)
+
+
+def test_run_minimal_self_user_in_input():
+    """
+    Tests a minimal run of the job lookup method as a standard user with the user's own username
+    passed into the method.
+    The returned job has minimal fields.
+    """
+    _run_minimal(USER1)
+
+
+def _run_minimal(user):
+    # set up constants
+    expected_user = USER1
+    job_count = 26
+    objectid = "603051cfaf2e3401b0500982"
+    created_state = "created"
+
+    # set up mock return values. Ordered as per the call order in the EE2SR code.
+    sdkmr = create_autospec(SDKMethodRunner, spec_set=True, instance=True)
+    logger = create_autospec(Logger, spec_set=True, instance=True)
+    sdkmr.get_logger.return_value = logger
+    sdkmr.get_user_id.return_value = expected_user
+    sdkmr.check_and_convert_time.side_effect = [35.6, 92.4]
+    sdkmr.get_job_counts.return_value = job_count
+
+    j = Job()
+    j.id = ObjectId(objectid)
+    j.user = expected_user
+    j.updated = 1000000.0
+    j.status = created_state
+    sdkmr.get_jobs.return_value = [j]
+
+    # call the method
+    ee2sr = JobStatusRange(sdkmr)
+    ret = ee2sr.check_jobs_date_range_for_user("5/6/21", "7/6/21", user=user)
+
+    assert ret == {
+        'count': 1,
+        'filter': {'id__gt': '000000230000000000000000',
+                   'id__lt': '0000005c0000000000000000',
+                   'user': expected_user},
+        'jobs': [{'_id': objectid,
+                  'authstrat': 'kbaseworkspace',
+                  'batch_job': False,
+                  'child_jobs': [],
+                  'created': 1613779407000,
+                  'job_id': objectid,
+                  'status': created_state,
+                  'updated': 1000000000,
+                  'user': expected_user}],
+        'limit': 2000,
+        'projection': [],
+        'query_count': job_count,
+        'skip': 0,
+        'sort_order': '+',
+        'stats': {'app_id': {None: 1},
+                  'clientgroup': {None: 1},
+                  'method': {None: 1},
+                  'status': {created_state: 1},
+                  'user': {expected_user: 1},
+                  'wsid': {None: 1}
+                  }
+    }
+
+    # check mocks called as expected. Ordered as per the call order in the EE2SR code
+    sdkmr.check_and_convert_time.assert_has_calls([call("5/6/21"), call("7/6/21")])
+    expected_job_filter = {
+        'id__gt': '000000230000000000000000',
+        'id__lt': '0000005c0000000000000000',
+        'user': expected_user
+    }
+    sdkmr.get_job_counts.assert_called_once_with(expected_job_filter)
+    sdkmr.get_jobs.assert_called_once_with(expected_job_filter, [], '+', 0, 2000)
+    logger.debug.assert_called_once_with(
+        'Searching for jobs with id_gt 000000230000000000000000 id_lt 0000005c0000000000000000')

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -20,7 +20,7 @@ from mock import MagicMock
 from execution_engine2.authorization.workspaceauth import WorkspaceAuth
 from lib.execution_engine2.db.MongoUtil import MongoUtil
 from lib.execution_engine2.db.models.models import Job, Status, TerminatedCode
-from lib.execution_engine2.exceptions import AuthError
+from execution_engine2.exceptions import AuthError
 from lib.execution_engine2.exceptions import InvalidStatusTransitionException
 from lib.execution_engine2.sdk.SDKMethodRunner import SDKMethodRunner
 from lib.execution_engine2.utils.CondorTuples import SubmissionInfo, CondorResources


### PR DESCRIPTION
# Description of PR purpose/changes

Also add unit tests.

Previously if the user was None it would be set to the user's name, but
that behavior was [mistakenly removed](https://github.com/kbase/execution_engine2/pull/294/files#diff-6d81ae439caaea9fb9b5db38b7b8c490b9ea5ef32cd59292797bf14fdf5da751L77-R78) when making user_id and token
required fields in SDKMR. Without that behavior, a user = None filter is added to
the mongo query which matches no jobs.

Closes #318.

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3K+ warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
