### PR TITLE
Fix finish_job bug, add tests

### DIFF
--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -355,9 +355,9 @@ class JobsStatus:
                 )
             )
         else:
-            self.sdkmr.logger.debug("Finishing job with a success")
+            self.sdkmr.get_logger().debug("Finishing job with a success")
             self._finish_job_with_success(job_id=job_id, job_output=job_output)
-            self.sdkmr.kafka_client.send_kafka_message(
+            self.sdkmr.get_kafka_client().send_kafka_message(
                 message=KafkaFinishJob(
                     job_id=str(job_id),
                     new_status=Status.completed.value,
@@ -391,7 +391,7 @@ class JobsStatus:
             )
         condor = self.sdkmr.get_condor()
         resources = condor.get_job_resource_info(job_id=job_id)
-        self.sdkmr.logger.debug(f"Extracted the following condor job ads {resources}")
+        self.sdkmr.get_logger().debug(f"Extracted the following condor job ads {resources}")
         self.sdkmr.get_mongo_util().update_job_resources(
             job_id=job_id, resources=resources
         )
@@ -547,7 +547,7 @@ class JobsStatus:
         log_exec_stats_params["is_error"] = int(job.status == Status.error.value)
         log_exec_stats_params["job_id"] = job_id
 
-        self.sdkmr.catalog_utils.catalog.log_exec_stats(log_exec_stats_params)
+        self.sdkmr.get_catalog_utils().get_catalog().log_exec_stats(log_exec_stats_params)
 
     def abandon_children(self, parent_job_id, child_job_ids, as_admin=False) -> Dict:
         if not parent_job_id:

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -368,15 +368,16 @@ class JobsStatus:
                 )
             )
             self._send_exec_stats_to_catalog(job_id=job_id)
-        self.update_finished_job_with_usage(job_id, as_admin=as_admin)
+        self._update_finished_job_with_usage(job_id, as_admin=as_admin)
 
-    def update_finished_job_with_usage(self, job_id, as_admin=None) -> Dict:
+    def _update_finished_job_with_usage(self, job_id, as_admin=None) -> Dict:
         """
         # TODO Does this need a kafka message?
         :param job_id:
         :param as_admin:
         :return:
         """
+        # note this method is replaced by a magic mock in some tests
         job = self.sdkmr.get_job_with_permission(
             job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=as_admin
         )

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -391,7 +391,9 @@ class JobsStatus:
             )
         condor = self.sdkmr.get_condor()
         resources = condor.get_job_resource_info(job_id=job_id)
-        self.sdkmr.get_logger().debug(f"Extracted the following condor job ads {resources}")
+        self.sdkmr.get_logger().debug(
+            f"Extracted the following condor job ads {resources}"
+        )
         self.sdkmr.get_mongo_util().update_job_resources(
             job_id=job_id, resources=resources
         )
@@ -547,7 +549,9 @@ class JobsStatus:
         log_exec_stats_params["is_error"] = int(job.status == Status.error.value)
         log_exec_stats_params["job_id"] = job_id
 
-        self.sdkmr.get_catalog_utils().get_catalog().log_exec_stats(log_exec_stats_params)
+        self.sdkmr.get_catalog_utils().get_catalog().log_exec_stats(
+            log_exec_stats_params
+        )
 
     def abandon_children(self, parent_job_id, child_job_ids, as_admin=False) -> Dict:
         if not parent_job_id:

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for the EE2Status class.
+"""
+
+from pytest import raises
+
+from logging import Logger
+from unittest.mock import create_autospec, call
+from bson.objectid import ObjectId
+
+from execution_engine2.db.models.models import Job, Status, JobInput
+from execution_engine2.sdk.SDKMethodRunner import SDKMethodRunner
+from execution_engine2.sdk.EE2Status import JobsStatus, JobPermissions
+from execution_engine2.db.MongoUtil import MongoUtil
+from lib.execution_engine2.utils.KafkaUtils import KafkaClient, KafkaFinishJob
+from lib.execution_engine2.utils.CatalogUtils import CatalogUtils
+from lib.execution_engine2.utils.Condor import Condor
+from installed_clients.CatalogClient import Catalog
+
+from utils_shared.test_utils import assert_exception_correct
+
+
+def _finish_job_complete_minimal_get_test_job(job_id, sched, app_id, gitcommit, user):
+    job = Job()
+    job.id = ObjectId(job_id)
+    job.running = 123.0
+    job.finished = 456.5
+    job.status = Status.running.value
+    job.scheduler_id = sched
+    job_input = JobInput()
+    job.job_input = job_input
+    job_input.app_id = app_id
+    job_input.method = "module.method_id"
+    job_input.service_ver = gitcommit
+    job.user = user
+    return job
+
+
+def test_finish_job_complete_minimal():
+    """
+    Tests a very simple case of completing a job successfully by the `finish_job` method.
+    """
+    # set up constants
+    job_id = "6046b539ce9c58ecf8c3e5f3"
+    job_output = {
+        'version': '1.1',
+        'id': job_id,
+        'result': [{"foo": "bar"}]
+    }
+    user = "someuser"
+    app_id = "module/myapp"
+    gitcommit = "somecommit"
+    resources = {
+        "fake": "condor",
+        "resources": "in",
+        "here": "yo"
+    }
+    sched = "somescheduler"
+
+    # set up mocks
+    sdkmr = create_autospec(SDKMethodRunner, spec_set=True, instance=True)
+    logger = create_autospec(Logger, spec_set=True, instance=True)
+    mongo = create_autospec(MongoUtil, spec_set=True, instance=True)
+    kafka = create_autospec(KafkaClient, spec_set=True, instance=True)
+    catutil = create_autospec(CatalogUtils, spec_set=True, instance=True)
+    catalog = create_autospec(Catalog, spec_set=True, instance=True)
+    condor = create_autospec(Condor, spec_set=True, instance=True)
+    sdkmr.get_mongo_util.return_value = mongo
+    sdkmr.get_logger.return_value = logger
+    sdkmr.get_kafka_client.return_value = kafka
+    sdkmr.get_condor.return_value = condor
+    sdkmr.get_catalog_utils.return_value = catutil
+    catutil.get_catalog.return_value = catalog
+
+    # set up return values for mocks. Ordered as per order of operations in code
+    job1 = _finish_job_complete_minimal_get_test_job(job_id, sched, app_id, gitcommit, user)
+    job2 = _finish_job_complete_minimal_get_test_job(job_id, sched, app_id, gitcommit, user)
+    job2.status = Status.completed.value
+
+    sdkmr.get_job_with_permission.side_effect = [job1, job2]
+    mongo.get_job.return_value = job2  # gets the job 3x...?
+    condor.get_job_resource_info.return_value = resources
+
+    # call the method
+    JobsStatus(sdkmr).finish_job(job_id, job_output=job_output)  # no return
+
+    # check mocks called as expected. Ordered as per order of operations in code
+
+    sdkmr.get_job_with_permission.assert_has_calls([
+        call(job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=False),
+        call(job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=False)
+    ])
+    logger.debug.assert_has_calls([
+        call("Finishing job with a success"),
+        # depending on stable dict ordering for this test to pass
+        call(f"Extracted the following condor job ads {resources}")
+    ])
+    mongo.finish_job_with_success.assert_called_once_with(job_id, job_output)
+    kafka.send_kafka_message.assert_called_once_with(
+        KafkaFinishJob(
+            job_id=job_id,
+            new_status=Status.completed.value,
+            previous_status=Status.running.value,
+            scheduler_id=sched,
+            error_code=None,
+            error_message=None,
+        )
+    )
+    mongo.get_job.assert_called_once_with(job_id)
+    catalog.log_exec_stats.assert_called_once_with({
+        "user_id": user,
+        "app_module_name": "module",
+        "app_id": app_id,
+        "func_module_name": "module",
+        "func_name": "method_id",
+        "git_commit_hash": gitcommit,
+        "creation_time": 1615246649.0,  # from Job ObjectId
+        "exec_start_time": 123.0,
+        "finish_time": 456.5,
+        "is_error": 0,
+        "job_id": job_id
+    })
+    mongo.update_job_resources.assert_called_once_with(job_id, resources)

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -2,8 +2,6 @@
 Unit tests for the EE2Status class.
 """
 
-from pytest import raises
-
 from logging import Logger
 from unittest.mock import create_autospec, call
 from bson.objectid import ObjectId
@@ -16,8 +14,6 @@ from lib.execution_engine2.utils.KafkaUtils import KafkaClient, KafkaFinishJob
 from lib.execution_engine2.utils.CatalogUtils import CatalogUtils
 from lib.execution_engine2.utils.Condor import Condor
 from installed_clients.CatalogClient import Catalog
-
-from utils_shared.test_utils import assert_exception_correct
 
 
 def _finish_job_complete_minimal_get_test_job(job_id, sched, app_id, gitcommit, user):

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -42,19 +42,11 @@ def test_finish_job_complete_minimal():
     """
     # set up constants
     job_id = "6046b539ce9c58ecf8c3e5f3"
-    job_output = {
-        'version': '1.1',
-        'id': job_id,
-        'result': [{"foo": "bar"}]
-    }
+    job_output = {"version": "1.1", "id": job_id, "result": [{"foo": "bar"}]}
     user = "someuser"
     app_id = "module/myapp"
     gitcommit = "somecommit"
-    resources = {
-        "fake": "condor",
-        "resources": "in",
-        "here": "yo"
-    }
+    resources = {"fake": "condor", "resources": "in", "here": "yo"}
     sched = "somescheduler"
 
     # set up mocks
@@ -73,8 +65,12 @@ def test_finish_job_complete_minimal():
     catutil.get_catalog.return_value = catalog
 
     # set up return values for mocks. Ordered as per order of operations in code
-    job1 = _finish_job_complete_minimal_get_test_job(job_id, sched, app_id, gitcommit, user)
-    job2 = _finish_job_complete_minimal_get_test_job(job_id, sched, app_id, gitcommit, user)
+    job1 = _finish_job_complete_minimal_get_test_job(
+        job_id, sched, app_id, gitcommit, user
+    )
+    job2 = _finish_job_complete_minimal_get_test_job(
+        job_id, sched, app_id, gitcommit, user
+    )
     job2.status = Status.completed.value
 
     sdkmr.get_job_with_permission.side_effect = [job1, job2]
@@ -86,15 +82,23 @@ def test_finish_job_complete_minimal():
 
     # check mocks called as expected. Ordered as per order of operations in code
 
-    sdkmr.get_job_with_permission.assert_has_calls([
-        call(job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=False),
-        call(job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=False)
-    ])
-    logger.debug.assert_has_calls([
-        call("Finishing job with a success"),
-        # depending on stable dict ordering for this test to pass
-        call(f"Extracted the following condor job ads {resources}")
-    ])
+    sdkmr.get_job_with_permission.assert_has_calls(
+        [
+            call(
+                job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=False
+            ),
+            call(
+                job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=False
+            ),
+        ]
+    )
+    logger.debug.assert_has_calls(
+        [
+            call("Finishing job with a success"),
+            # depending on stable dict ordering for this test to pass
+            call(f"Extracted the following condor job ads {resources}"),
+        ]
+    )
     mongo.finish_job_with_success.assert_called_once_with(job_id, job_output)
     kafka.send_kafka_message.assert_called_once_with(
         KafkaFinishJob(
@@ -107,17 +111,19 @@ def test_finish_job_complete_minimal():
         )
     )
     mongo.get_job.assert_called_once_with(job_id)
-    catalog.log_exec_stats.assert_called_once_with({
-        "user_id": user,
-        "app_module_name": "module",
-        "app_id": app_id,
-        "func_module_name": "module",
-        "func_name": "method_id",
-        "git_commit_hash": gitcommit,
-        "creation_time": 1615246649.0,  # from Job ObjectId
-        "exec_start_time": 123.0,
-        "finish_time": 456.5,
-        "is_error": 0,
-        "job_id": job_id
-    })
+    catalog.log_exec_stats.assert_called_once_with(
+        {
+            "user_id": user,
+            "app_module_name": "module",
+            "app_id": app_id,
+            "func_module_name": "module",
+            "func_name": "method_id",
+            "git_commit_hash": gitcommit,
+            "creation_time": 1615246649.0,  # from Job ObjectId
+            "exec_start_time": 123.0,
+            "finish_time": 456.5,
+            "is_error": 0,
+            "job_id": job_id,
+        }
+    )
     mongo.update_job_resources.assert_called_once_with(job_id, resources)

--- a/test/tests_for_sdkmr/ee2_load_test.py
+++ b/test/tests_for_sdkmr/ee2_load_test.py
@@ -62,7 +62,7 @@ class ee2_server_load_test(unittest.TestCase):
         # Initialize these clients from None
         status = runner.get_jobs_status()  # type: JobsStatus
         status._send_exec_stats_to_catalog = MagicMock(return_value=True)
-        status.update_finished_job_with_usage = MagicMock(return_value=True)
+        status._update_finished_job_with_usage = MagicMock(return_value=True)
         runjob = runner.get_runjob()
         runjob._get_module_git_commit = MagicMock(return_value="GitCommithash")
         runner.get_job_logs()


### PR DESCRIPTION
# Description of PR purpose/changes

EE2status attempting to access get_catalog_utils().catalog caused
finish_job() to throw an exception and consequently the job runner to freak out:

kbase/JobRunner#43

Accessed the catalog directly and added a unit test that covers the code
in question.

Also reduced the EE2Status API by making a method that was only used in tests "private".

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
