### PR TITLE
Fix bug processing catalog client groups in CSV format

### DIFF
--- a/lib/execution_engine2/utils/CatalogUtils.py
+++ b/lib/execution_engine2/utils/CatalogUtils.py
@@ -57,7 +57,7 @@ class CatalogUtils:
             json_resources_request = ", ".join(resources_request)
             return json.loads(json_resources_request)
         # CSV Format
-        rr = resources_request[0].split(",")  # type: list
+        rr = resources_request  # type: list
         rv = {"client_group": rr.pop(0)}
         for item in rr:
             if "=" not in item:

--- a/test/tests_for_sdkmr/ee2_scheduler_test.py
+++ b/test/tests_for_sdkmr/ee2_scheduler_test.py
@@ -81,7 +81,7 @@ class ExecutionEngine2SchedulerTest(unittest.TestCase):
         logging.info("Testing with complex-empty clientgroup")
 
         params = self._create_sample_params(
-            cgroups=["njs,request_cpus=8,request_memory=10GB,request_apples=5"]
+            cgroups=["njs", "request_cpus=8", "request_memory=10GB", "request_apples=5"]
         )
 
         njs_sub = c._create_submit(params)


### PR DESCRIPTION
# Description of PR purpose/changes

Fixes: https://github.com/kbase/execution_engine2/issues/332

In short, the CSV inputs shown in the catalog UI are already split into
separate strings before being sent to the catalog, so the split is not
necessary. Only accepting the first entry in the list causes everything
except the client group to be ignored.

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
