### PR TITLE
Add release notes for CSV bugfix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # execution_engine2 (ee2) release notes
 =========================================
+## 0.0.5
+  * Fix a bug that caused job requirements from the catalog in CSV format to be ignored other
+    than the client group
+
 ## 0.0.4
   * Fix up tests
   * Remove dependency on slack


### PR DESCRIPTION
# Description of PR purpose/changes

Missed release notes for #333

This repo doesn't seem to bump a version anywhere other than the release notes

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [n/a ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [X] [Version has been bumped](https://semver.org/) for each release
- [X] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
