### PR TITLE
DATAUP-389: Add a job requirements checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,34 @@ pre-commit uninstall
     * Once the PR is apporoved, merge (no squash) to `main`.
     * Tag the merge commit in GitHub with the semantic version from `kbase.yml`.
  
+## KBase Catalog interactions
+
+### Client Groups
+
+EE2 understands client group specifications in JSON and CSV formats. Both formats have special
+fields in common:
+* `request_cpus` - the number of CPUs to request
+* `request_memory` - the amount of memory, in MB, to request
+* `request_disk` - the amount of memory, in GB, to request
+* `client_group_regex` - treat the client group (see below) as a regular expression
+* `debug_mode` - run the job in debug mode
+
+The client group is handled differently for JSON and CSV:
+* The JSON format has the `clientgroup` field, which is optional.
+* The CSV format must have the client group in the first 'column' of the CSV and is required. The
+  remainder of the 'columns' must be in `key=value` format.
+
+Any fields other than the above are sent on to the scheduler as key value pairs.
+
+For example, to set the client group to `bigmem`, request 32 CPUs, 64GB of memory, and 1TB of disk,
+the following would be entered in the catalog UI:
+* CSV: `bigmem, request_cpus=32, request_memory=64000, request_disk=1000`
+* JSON: `{"client_group": "bigmem", "request_cpus" : "32", "request_memory" : "64000", "request_disk" : "1000"}`
+
+Note that the representation of this data in the catalog API is idiosyncratic - both the JSON and
+CSV data are split by commas into parts. EE2 will detect JSON entries and reconsitute them before
+deserialization.
+
 # Help  
   
 Contact @Tianhao-Gu, @bio_boris, @briehl

--- a/lib/execution_engine2/sdk/job_submission_parameters.py
+++ b/lib/execution_engine2/sdk/job_submission_parameters.py
@@ -33,7 +33,7 @@ class JobRequirements:
         disk_GB: int,
         client_group: str,
         client_group_regex: Union[bool, None] = None,
-        as_user: str = None,
+        bill_to_user: str = None,
         ignore_concurrency_limits: bool = False,
         scheduler_requirements: Dict[str, str] = None,
         debug_mode: bool = False,
@@ -47,7 +47,7 @@ class JobRequirements:
         client_group - the client group in which the job will run.
         client_group_regex - whether to treat the client group string as a regular expression
             that can match multiple client groups. Pass None for no preference.
-        as_user - run the job as an alternate user; takes the user's username.
+        bill_to_user - bill the job to an alternate user; takes the user's username.
         ignore_concurrency_limits - allow the user to run this job even if the user's maximum
             job count has already been reached.
         scheduler_requirements - arbitrary requirements for the scheduler passed as key/value
@@ -61,7 +61,7 @@ class JobRequirements:
         self.client_group_regex = (
             None if client_group_regex is None else bool(client_group_regex)
         )
-        self.as_user = _check_string(as_user, "as_user", optional=True)
+        self.bill_to_user = _check_string(bill_to_user, "bill_to_user", optional=True)
         self.ignore_concurrency_limits = bool(ignore_concurrency_limits)
         self.scheduler_requirements = FrozenMap(
             self._check_scheduler_requirements(scheduler_requirements)
@@ -86,7 +86,7 @@ class JobRequirements:
         disk_GB: int = None,
         client_group: str = None,
         client_group_regex: Union[bool, None] = None,
-        as_user: str = None,
+        bill_to_user: str = None,
         ignore_concurrency_limits: bool = False,
         scheduler_requirements: Dict[str, str] = None,
         debug_mode: bool = False,
@@ -101,7 +101,7 @@ class JobRequirements:
         client_group - the client group in which the job will run.
         client_group_regex - whether to treat the client group string as a regular expression
             that can match multiple client groups.
-        as_user - run the job as an alternate user; takes the user's username.
+        bill_to_user - bill the job to an alternate user; takes the user's username.
         ignore_concurrency_limits - allow the user to run this job even if the user's maximum
             job count has already been reached.
         scheduler_requirements - arbitrary requirements for the scheduler passed as key/value
@@ -123,7 +123,7 @@ class JobRequirements:
             disk_GB,
             client_group,
             None if client_group_regex is None else bool(client_group_regex),
-            _check_string(as_user, "as_user", optional=True),
+            _check_string(bill_to_user, "bill_to_user", optional=True),
             bool(ignore_concurrency_limits),
             cls._check_scheduler_requirements(scheduler_requirements),
             bool(debug_mode),
@@ -136,7 +136,7 @@ class JobRequirements:
             self.disk_GB,
             self.client_group,
             self.client_group_regex,
-            self.as_user,
+            self.bill_to_user,
             self.ignore_concurrency_limits,
             self.scheduler_requirements,
             self.debug_mode,
@@ -150,7 +150,7 @@ class JobRequirements:
                 other.disk_GB,
                 other.client_group,
                 other.client_group_regex,
-                other.as_user,
+                other.bill_to_user,
                 other.ignore_concurrency_limits,
                 other.scheduler_requirements,
                 other.debug_mode,

--- a/lib/execution_engine2/sdk/job_submission_parameters.py
+++ b/lib/execution_engine2/sdk/job_submission_parameters.py
@@ -85,15 +85,15 @@ class JobRequirements:
         memory_MB: int = None,
         disk_GB: int = None,
         client_group: str = None,
-        client_group_regex: bool = False,
+        client_group_regex: Union[bool, None] = None,
         as_user: str = None,
         ignore_concurrency_limits: bool = False,
         scheduler_requirements: Dict[str, str] = None,
         debug_mode: bool = False,
     ):
         """
-        Test that a set of parameters are legal. All arguments are optional - parameters required
-        for initializing the class may be missing.
+        Test that a set of parameters are legal and returns normalized parmeters.
+        All arguments are optional - parameters required for initializing the class may be missing.
 
         cpus - the number of CPUs required for the job.
         memory_MB - the amount of memory, in MB, required for the job.
@@ -116,12 +116,18 @@ class JobRequirements:
         if disk_GB is not None:
             _gt_zero(disk_GB, "disk space in GB")
         if client_group is not None:
-            _check_string(client_group, "client_group")
-        # do nothing for client group regex, any value is acceptable
-        _check_string(as_user, "as_user", optional=True)
-        # do nothing for ignore con limits, any value is acceptable
-        cls._check_scheduler_requirements(scheduler_requirements)
-        # do nothing for debug_mode, any value is acceptable
+            client_group = _check_string(client_group, "client_group")
+        return (
+            cpus,
+            memory_MB,
+            disk_GB,
+            client_group,
+            None if client_group_regex is None else bool(client_group_regex),
+            _check_string(as_user, "as_user", optional=True),
+            bool(ignore_concurrency_limits),
+            cls._check_scheduler_requirements(scheduler_requirements),
+            bool(debug_mode),
+        )
 
     def _params(self):
         return (

--- a/lib/execution_engine2/sdk/job_submission_parameters.py
+++ b/lib/execution_engine2/sdk/job_submission_parameters.py
@@ -47,7 +47,7 @@ class JobRequirements:
         client_group - the client group in which the job will run.
         client_group_regex - whether to treat the client group string as a regular expression
             that can match multiple client groups. Pass None for no preference.
-        as_user - run the job as an alternate user; take the user's username.
+        as_user - run the job as an alternate user; takes the user's username.
         ignore_concurrency_limits - allow the user to run this job even if the user's maximum
             job count has already been reached.
         scheduler_requirements - arbitrary requirements for the scheduler passed as key/value
@@ -58,17 +58,67 @@ class JobRequirements:
         self.memory_MB = _gt_zero(memory_MB, "memory in MB")
         self.disk_GB = _gt_zero(disk_GB, "disk space in GB")
         self.client_group = _check_string(client_group, "client_group")
-        self.client_group_regex = client_group_regex
+        self.client_group_regex = None if client_group_regex is None else bool(client_group_regex)
         self.as_user = _check_string(as_user, "as_user", optional=True)
-        self.ignore_concurrency_limits = ignore_concurrency_limits
-        sr = scheduler_requirements if scheduler_requirements else {}
+        self.ignore_concurrency_limits = bool(ignore_concurrency_limits)
+        self.scheduler_requirements = FrozenMap(self._check_scheduler_requirements(
+            scheduler_requirements))
+        self.debug_mode = bool(debug_mode)
+
+    @classmethod
+    def _check_scheduler_requirements(cls, schd_reqs):
+        sr = schd_reqs if schd_reqs else {}
         for key, value in sr.items():
             _check_string(key, "key in scheduler requirements structure")
             _check_string(
                 value, f"value for key '{key}' in scheduler requirements structure"
             )
-        self.scheduler_requirements = FrozenMap(sr)
-        self.debug_mode = debug_mode
+        return sr
+
+    @classmethod
+    def check_parameters(
+        cls,
+        cpus: int = None,
+        memory_MB: int = None,
+        disk_GB: int = None,
+        client_group: str = None,
+        client_group_regex: bool = False,
+        as_user: str = None,
+        ignore_concurrency_limits: bool = False,
+        scheduler_requirements: Dict[str, str] = None,
+        debug_mode: bool = False
+    ):
+        """
+        Test that a set of parameters are legal. All arguments are optional - parameters required
+        for initializing the class may be missing.
+
+        cpus - the number of CPUs required for the job.
+        memory_MB - the amount of memory, in MB, required for the job.
+        disk_GB - the amount of disk space, in GB, required for the job.
+        client_group - the client group in which the job will run.
+        client_group_regex - whether to treat the client group string as a regular expression
+            that can match multiple client groups.
+        as_user - run the job as an alternate user; takes the user's username.
+        ignore_concurrency_limits - allow the user to run this job even if the user's maximum
+            job count has already been reached.
+        scheduler_requirements - arbitrary requirements for the scheduler passed as key/value
+            pairs. Requires knowledge of the scheduler API.
+        """
+        # Could add a check_required_parameters bool if needed, but YAGNI for now. Any missing
+        # required paramaters will be looked up from the catalog or EE2 config file.
+        if cpus is not None:
+            _gt_zero(cpus, "CPU count")
+        if memory_MB is not None:
+            _gt_zero(memory_MB, "memory in MB")
+        if disk_GB is not None:
+            _gt_zero(disk_GB, "disk space in GB")
+        if client_group is not None:
+            _check_string(client_group, "client_group")
+        # do nothing for client group regex, any value is acceptable
+        _check_string(as_user, "as_user", optional=True)
+        # do nothing for ignore con limits, any value is acceptable
+        cls._check_scheduler_requirements(scheduler_requirements)
+        # do nothing for debug_mode, any value is acceptable
 
     def _params(self):
         return (

--- a/lib/execution_engine2/sdk/job_submission_parameters.py
+++ b/lib/execution_engine2/sdk/job_submission_parameters.py
@@ -58,11 +58,14 @@ class JobRequirements:
         self.memory_MB = _gt_zero(memory_MB, "memory in MB")
         self.disk_GB = _gt_zero(disk_GB, "disk space in GB")
         self.client_group = _check_string(client_group, "client_group")
-        self.client_group_regex = None if client_group_regex is None else bool(client_group_regex)
+        self.client_group_regex = (
+            None if client_group_regex is None else bool(client_group_regex)
+        )
         self.as_user = _check_string(as_user, "as_user", optional=True)
         self.ignore_concurrency_limits = bool(ignore_concurrency_limits)
-        self.scheduler_requirements = FrozenMap(self._check_scheduler_requirements(
-            scheduler_requirements))
+        self.scheduler_requirements = FrozenMap(
+            self._check_scheduler_requirements(scheduler_requirements)
+        )
         self.debug_mode = bool(debug_mode)
 
     @classmethod
@@ -86,7 +89,7 @@ class JobRequirements:
         as_user: str = None,
         ignore_concurrency_limits: bool = False,
         scheduler_requirements: Dict[str, str] = None,
-        debug_mode: bool = False
+        debug_mode: bool = False,
     ):
         """
         Test that a set of parameters are legal. All arguments are optional - parameters required

--- a/test/deploy.cfg
+++ b/test/deploy.cfg
@@ -80,7 +80,7 @@ request_disk = 100GB
 [hpc]
 request_cpus = 4
 request_memory = 2000M
-request_disk = 100GBraiss
+request_disk = 100GB
 #---------------------------------------------------------------------------------------#
 [DEFAULT]
 default_client_group = njs

--- a/test/tests_for_sdkmr/job_submission_parameters_test.py
+++ b/test/tests_for_sdkmr/job_submission_parameters_test.py
@@ -200,14 +200,15 @@ def _job_req_init_fail(cpus, mem, disk, cgroup, user, reqs, expected):
 
 
 def test_job_req_check_parameters_no_input():
-    # if no exception, success
-    JobRequirements.check_parameters()
     n = None
-    JobRequirements.check_parameters(n, n, n, n, n, n, n, n, n)
+    f = False
+    assert JobRequirements.check_parameters() == (n, n, n, n, n, n, f, {}, f)
+    assert JobRequirements.check_parameters(n, n, n, n, n, n, n, n, n) == (
+        n, n, n, n, n, n, f, {}, f)
 
 
 def test_job_req_check_parameters_full_input():
-    JobRequirements.check_parameters(  # if no exception, success
+    assert JobRequirements.check_parameters(
         1,
         1,
         1,
@@ -217,21 +218,21 @@ def test_job_req_check_parameters_full_input():
         890,
         {"proc": "x286", "maxmem": "640k"},
         [],
-    )
+    ) == (1, 1, 1, "b", True, "user", True, {"proc": "x286", "maxmem": "640k"}, False)
 
 
 def test_job_req_check_parameters_whitespace_as_user():
-    JobRequirements.check_parameters(  # if no exception, success
+    assert JobRequirements.check_parameters(
         1,
         1,
         1,
         "   b   ",
-        "x",
+        False,
         " \t  ",
         890,
         {"proc": "x286", "maxmem": "640k"},
         [],
-    )
+    ) == (1, 1, 1, "b", False, None, True, {"proc": "x286", "maxmem": "640k"}, False)
 
 
 def test_job_req_check_parameters_fail():

--- a/test/tests_for_sdkmr/job_submission_parameters_test.py
+++ b/test/tests_for_sdkmr/job_submission_parameters_test.py
@@ -17,7 +17,7 @@ def test_job_req_init_minimal():
     assert jr.disk_GB == 1
     assert jr.client_group == "njs"
     assert jr.client_group_regex is None
-    assert jr.as_user is None
+    assert jr.bill_to_user is None
     assert jr.ignore_concurrency_limits is False
     assert jr.scheduler_requirements == {}
     assert jr.debug_mode is False
@@ -28,9 +28,9 @@ def test_job_req_init_maximal():
         6,
         7,
         8,
-        "bigmemlong",
+        "   bigmemlong  \t  ",
         True,
-        "someuser",
+        "\tsomeuser     ",
         True,
         {"proc": "x286", "maxmem": "640k"},
         True,
@@ -41,7 +41,7 @@ def test_job_req_init_maximal():
     assert jr.disk_GB == 8
     assert jr.client_group == "bigmemlong"
     assert jr.client_group_regex is True
-    assert jr.as_user == "someuser"
+    assert jr.bill_to_user == "someuser"
     assert jr.ignore_concurrency_limits is True
     assert jr.scheduler_requirements == {"proc": "x286", "maxmem": "640k"}
     assert jr.debug_mode is True
@@ -145,7 +145,7 @@ def test_job_req_init_fail():
         "f",
         "user\tname",
         n,
-        IncorrectParamsException("as_user contains control characters"),
+        IncorrectParamsException("bill_to_user contains control characters"),
     )
     _job_req_init_fail(
         1,
@@ -289,7 +289,7 @@ def test_job_req_check_parameters_fail():
         "c",
         "  j\bi  ",
         n,
-        IncorrectParamsException("as_user contains control characters"),
+        IncorrectParamsException("bill_to_user contains control characters"),
     )
     _job_req_check_parameters_fail(
         1,

--- a/test/tests_for_sdkmr/job_submission_parameters_test.py
+++ b/test/tests_for_sdkmr/job_submission_parameters_test.py
@@ -49,7 +49,13 @@ def test_job_req_init_maximal():
 
 def test_job_req_init_non_bools():
     for inp, expected in {
-            1: True, " ": True, (1,): True, 0: False, "": False, tuple(): False}.items():
+        1: True,
+        " ": True,
+        (1,): True,
+        0: False,
+        "": False,
+        tuple(): False,
+    }.items():
         jr = JobRequirements(
             6,
             7,
@@ -57,7 +63,8 @@ def test_job_req_init_non_bools():
             "cg",
             client_group_regex=inp,
             ignore_concurrency_limits=inp,
-            debug_mode=inp)
+            debug_mode=inp,
+        )
 
         assert jr.client_group_regex is expected
         assert jr.ignore_concurrency_limits is expected
@@ -72,7 +79,8 @@ def test_job_req_init_None_for_bools():
         "cg",
         client_group_regex=None,
         ignore_concurrency_limits=None,
-        debug_mode=None)
+        debug_mode=None,
+    )
 
     assert jr.client_group_regex is None
     assert jr.ignore_concurrency_limits is False
@@ -204,7 +212,7 @@ def test_job_req_check_parameters_full_input():
         1,
         1,
         "   b   ",
-        'x',
+        "x",
         " user ",
         890,
         {"proc": "x286", "maxmem": "640k"},
@@ -218,7 +226,7 @@ def test_job_req_check_parameters_whitespace_as_user():
         1,
         1,
         "   b   ",
-        'x',
+        "x",
         " \t  ",
         890,
         {"proc": "x286", "maxmem": "640k"},
@@ -228,24 +236,89 @@ def test_job_req_check_parameters_whitespace_as_user():
 
 def test_job_req_check_parameters_fail():
     n = None
-    _job_req_check_parameters_fail(0, 1, 1, "c", "u", n, IncorrectParamsException(
-        "CPU count must be at least 1"))
-    _job_req_check_parameters_fail(1, 0, 1, "c", "u", n, IncorrectParamsException(
-        "memory in MB must be at least 1"))
-    _job_req_check_parameters_fail(1, 1, 0, "c", "u", n, IncorrectParamsException(
-        "disk space in GB must be at least 1"))
-    _job_req_check_parameters_fail(1, 1, 1, " \t ", "u", n, IncorrectParamsException(
-        "Missing input parameter: client_group"))
-    _job_req_check_parameters_fail(1, 1, 1, "c", "  j\bi  ", n, IncorrectParamsException(
-        "as_user contains control characters"))
-    _job_req_check_parameters_fail(1, 1, 1, "c", "u", {None: 1}, IncorrectParamsException(
-        "Missing input parameter: key in scheduler requirements structure"))
-    _job_req_check_parameters_fail(1, 1, 1, "c", "u", {"a": None}, IncorrectParamsException(
-        "Missing input parameter: value for key 'a' in scheduler requirements structure"))
-    _job_req_check_parameters_fail(1, 1, 1, "c", "u", {" \t ": 1}, IncorrectParamsException(
-        "Missing input parameter: key in scheduler requirements structure"))
-    _job_req_check_parameters_fail(1, 1, 1, "c", "u", {"b": " \t "}, IncorrectParamsException(
-        "Missing input parameter: value for key 'b' in scheduler requirements structure"))
+    _job_req_check_parameters_fail(
+        0, 1, 1, "c", "u", n, IncorrectParamsException("CPU count must be at least 1")
+    )
+    _job_req_check_parameters_fail(
+        1,
+        0,
+        1,
+        "c",
+        "u",
+        n,
+        IncorrectParamsException("memory in MB must be at least 1"),
+    )
+    _job_req_check_parameters_fail(
+        1,
+        1,
+        0,
+        "c",
+        "u",
+        n,
+        IncorrectParamsException("disk space in GB must be at least 1"),
+    )
+    _job_req_check_parameters_fail(
+        1,
+        1,
+        1,
+        " \t ",
+        "u",
+        n,
+        IncorrectParamsException("Missing input parameter: client_group"),
+    )
+    _job_req_check_parameters_fail(
+        1,
+        1,
+        1,
+        "c",
+        "  j\bi  ",
+        n,
+        IncorrectParamsException("as_user contains control characters"),
+    )
+    _job_req_check_parameters_fail(
+        1,
+        1,
+        1,
+        "c",
+        "u",
+        {None: 1},
+        IncorrectParamsException(
+            "Missing input parameter: key in scheduler requirements structure"
+        ),
+    )
+    _job_req_check_parameters_fail(
+        1,
+        1,
+        1,
+        "c",
+        "u",
+        {"a": None},
+        IncorrectParamsException(
+            "Missing input parameter: value for key 'a' in scheduler requirements structure"
+        ),
+    )
+    _job_req_check_parameters_fail(
+        1,
+        1,
+        1,
+        "c",
+        "u",
+        {" \t ": 1},
+        IncorrectParamsException(
+            "Missing input parameter: key in scheduler requirements structure"
+        ),
+    )
+    _job_req_check_parameters_fail(
+        1,
+        1,
+        1,
+        "c",
+        "u",
+        {"b": " \t "},
+        IncorrectParamsException(
+            "Missing input parameter: value for key 'b' in scheduler requirements structure"
+        ),
+    )
 
 
 def _job_req_check_parameters_fail(cpu, mem, disk, cgroup, user, reqs, expected):

--- a/test/tests_for_sdkmr/job_submission_parameters_test.py
+++ b/test/tests_for_sdkmr/job_submission_parameters_test.py
@@ -204,35 +204,50 @@ def test_job_req_check_parameters_no_input():
     f = False
     assert JobRequirements.check_parameters() == (n, n, n, n, n, n, f, {}, f)
     assert JobRequirements.check_parameters(n, n, n, n, n, n, n, n, n) == (
-        n, n, n, n, n, n, f, {}, f)
+        n,
+        n,
+        n,
+        n,
+        n,
+        n,
+        f,
+        {},
+        f,
+    )
 
 
 def test_job_req_check_parameters_full_input():
-    assert JobRequirements.check_parameters(
-        1,
-        1,
-        1,
-        "   b   ",
-        "x",
-        " user ",
-        890,
-        {"proc": "x286", "maxmem": "640k"},
-        [],
-    ) == (1, 1, 1, "b", True, "user", True, {"proc": "x286", "maxmem": "640k"}, False)
+    assert (
+        JobRequirements.check_parameters(
+            1,
+            1,
+            1,
+            "   b   ",
+            "x",
+            " user ",
+            890,
+            {"proc": "x286", "maxmem": "640k"},
+            [],
+        )
+        == (1, 1, 1, "b", True, "user", True, {"proc": "x286", "maxmem": "640k"}, False)
+    )
 
 
 def test_job_req_check_parameters_whitespace_as_user():
-    assert JobRequirements.check_parameters(
-        1,
-        1,
-        1,
-        "   b   ",
-        False,
-        " \t  ",
-        890,
-        {"proc": "x286", "maxmem": "640k"},
-        [],
-    ) == (1, 1, 1, "b", False, None, True, {"proc": "x286", "maxmem": "640k"}, False)
+    assert (
+        JobRequirements.check_parameters(
+            1,
+            1,
+            1,
+            "   b   ",
+            False,
+            " \t  ",
+            890,
+            {"proc": "x286", "maxmem": "640k"},
+            [],
+        )
+        == (1, 1, 1, "b", False, None, True, {"proc": "x286", "maxmem": "640k"}, False)
+    )
 
 
 def test_job_req_check_parameters_fail():


### PR DESCRIPTION
# Description of PR purpose/changes

Add a job requirements checker to be used in the job resolver prior to creating the requirements.

Minor changes:
* normalize booleans
* rename `as_user` to `bill_to_user` to clarify what the parameter does
* remove a typo in the test `deploy.cfg` file.
* document EE2 expectations of client group specifications in the catalog service

# Jira Ticket / Github Issue #
- [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
