### PR TITLE
DATAUP-389 - add a job requirements resolver, pt 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ fields in common:
 * `request_cpus` - the number of CPUs to request
 * `request_memory` - the amount of memory, in MB, to request
 * `request_disk` - the amount of memory, in GB, to request
-* `client_group_regex` - treat the client group (see below) as a regular expression
-* `debug_mode` - run the job in debug mode
+* `client_group_regex` - boolean - treat the client group (see below) as a regular expression
+* `debug_mode` - boolean - run the job in debug mode
 
 The client group is handled differently for JSON and CSV:
 * The JSON format has the `clientgroup` field, which is optional.

--- a/lib/execution_engine2/utils/job_requirements_resolver.py
+++ b/lib/execution_engine2/utils/job_requirements_resolver.py
@@ -72,9 +72,9 @@ def _bool_request(putative_bool, name, source):
     if type(putative_bool) == bool or type(putative_bool) == int:
         return bool(putative_bool)
     pbs = _string_request(putative_bool, name, source).lower()
-    if pbs == 'true':
+    if pbs == "true":
         return True
-    if pbs == 'false':
+    if pbs == "false":
         return False
     _check_raise(name, putative_bool, source)
 
@@ -138,8 +138,14 @@ class JobRequirementsResolver:
         if reqs is None:
             reqs = {}
         ret = {}
-        for key in [CLIENT_GROUP, REQUEST_CPUS, REQUEST_MEMORY, REQUEST_DISK,
-                    CLIENT_GROUP_REGEX, DEBUG_MODE]:
+        for key in [
+            CLIENT_GROUP,
+            REQUEST_CPUS,
+            REQUEST_MEMORY,
+            REQUEST_DISK,
+            CLIENT_GROUP_REGEX,
+            DEBUG_MODE,
+        ]:
             if not cls._has_value(reqs.get(key)):
                 if require_all_resources and key in _RESOURCES:
                     raise IncorrectParamsException(

--- a/lib/execution_engine2/utils/job_requirements_resolver.py
+++ b/lib/execution_engine2/utils/job_requirements_resolver.py
@@ -24,6 +24,8 @@ def _check_raise(name, value, source):
 
 def _check_clientgroup(clientgroup, source):
     clientgroup = _string_request(clientgroup, "client group", source)
+    # this is a possible error mode from the catalog since it uses key=value pairs in CSV
+    # format
     if "=" in clientgroup:
         _check_raise("client group", clientgroup, source)
     return clientgroup

--- a/lib/execution_engine2/utils/job_requirements_resolver.py
+++ b/lib/execution_engine2/utils/job_requirements_resolver.py
@@ -132,7 +132,7 @@ class JobRequirementsResolver:
             ({CLIENT_GROUP}, {REQUEST_CPUS}, {REQUEST_MEMORY}, {REQUEST_DISK}) aren't present
             with valid values.
 
-        Returns a a new dictionary with the altered keys. If any key is not present no action is
+        Returns a new dictionary with the altered keys. If any key is not present no action is
         taken for that key.
         """
         # TODO could support more units and convert as necessary (see checker funcs at start

--- a/lib/execution_engine2/utils/job_requirements_resolver.py
+++ b/lib/execution_engine2/utils/job_requirements_resolver.py
@@ -1,0 +1,158 @@
+"""
+Contains resolvers for job requirements.
+"""
+
+from typing import Dict, Union
+
+from execution_engine2.sdk.job_submission_parameters import JobRequirements
+from execution_engine2.exceptions import IncorrectParamsException
+
+CLIENT_GROUP = "client_group"
+REQUEST_CPUS = "request_cpus"
+REQUEST_MEMORY = "request_memory"
+REQUEST_DISK = "request_disk"
+CLIENT_GROUP_REGEX = "client_group_regex"
+DEBUG_MODE = "debug_mode"
+_RESOURCES = set([CLIENT_GROUP, REQUEST_CPUS, REQUEST_MEMORY, REQUEST_DISK])
+
+
+def _check_raise(name, value, source):
+    raise IncorrectParamsException(
+        f"Found illegal {name} '{value}' in job requirements from {source}"
+    )
+
+
+def _check_clientgroup(clientgroup, source):
+    clientgroup = _string_request(clientgroup, "client group", source)
+    if "=" in clientgroup:
+        _check_raise("client group", clientgroup, source)
+    return clientgroup
+
+
+def _string_request(putative_string, name, source):
+    if type(putative_string) != str:
+        _check_raise(name, putative_string, source)
+    return putative_string.strip()
+
+
+def _int_request(putative_int, original, name, source):
+    if type(putative_int) == float:
+        _check_raise(f"{name} request", original, source)
+    try:
+        return int(putative_int)
+    except ValueError:
+        _check_raise(f"{name} request", original, source)
+
+
+def _check_cpus(cpus, source):
+    return _int_request(cpus, cpus, "cpu", source)
+
+
+def _check_memory(memory, source):
+    if type(memory) == int:
+        return memory
+    memory2 = _string_request(memory, "memory request", source)
+    if memory2.endswith("M"):
+        memory2 = memory2[:-1]
+    elif memory2.endswith("MB"):
+        memory2 = memory2[:-2]
+    return _int_request(memory2, memory, "memory", source)
+
+
+def _check_disk(disk, source):
+    if type(disk) == int:
+        return disk
+    disk2 = _string_request(disk, "disk request", source)
+    if disk2.endswith("GB"):
+        disk2 = disk2[:-2]
+    return _int_request(disk2, disk, "disk", source)
+
+
+def _bool_request(putative_bool, name, source):
+    if type(putative_bool) == bool or type(putative_bool) == int:
+        return bool(putative_bool)
+    pbs = _string_request(putative_bool, name, source).lower()
+    if pbs == 'true':
+        return True
+    if pbs == 'false':
+        return False
+    _check_raise(name, putative_bool, source)
+
+
+def _check_client_group_regex(client_group_regex, source) -> bool:
+    return _bool_request(client_group_regex, "client group regex", source)
+
+
+def _check_debug_mode(debug_mode, source) -> bool:
+    return _bool_request(debug_mode, "debug mode", source)
+
+
+_KEY_CHECKERS = {
+    CLIENT_GROUP: _check_clientgroup,
+    REQUEST_CPUS: _check_cpus,
+    REQUEST_MEMORY: _check_memory,
+    REQUEST_DISK: _check_disk,
+    CLIENT_GROUP_REGEX: _check_client_group_regex,
+    DEBUG_MODE: _check_debug_mode,
+}
+
+
+class JobRequirementsResolver:
+    """
+    Resolves requirements for a job (e.g. CPU, memory, etc.) given a method id and optional input
+    parameters. Order of precedence is:
+    1) Parameters submitted by the client programmer
+    2) Requirements in the KBase Catalog service
+    3) Requirements from the EE2 configuration file (deploy.cfg).
+    """
+
+    @classmethod
+    def normalize_job_reqs(
+        cls, reqs: Dict[str, str], source: str, require_all_resources=False
+    ) -> Dict[str, Union[str, int]]:
+        f"""
+        Massage job requirements into a standard format. Does the following to specific keys of
+        the reqs argument:
+
+        {CLIENT_GROUP}: ensures it does not contain an =. This error mode is more probable in
+            the KBase catalog UI.
+        {REQUEST_CPUS}: parses to an int
+        {REQUEST_MEMORY}: parses to an int, removing a trailing 'M' or 'MB' if necessary.
+        {REQUEST_DISK}: parses to an int, removing a trailing 'GB' if necessary.
+        {CLIENT_GROUP_REGEX}: parses to a boolean or None. The strings true and false are
+            parsed to booleans, case-insensitive. Ints are parsed directly to booleans.
+        {DEBUG_MODE}: parses to a boolean. The strings true and false are parsed to booleans,
+            case-insensitive. Ints are parsed directly to booleans.
+
+        reqs - the job requirements
+        source - the source of the job requirements, e.g. catalog, user, etc.
+        require_all_resources - True to throw an error if all four keys resources keys
+            ({CLIENT_GROUP}, {REQUEST_CPUS}, {REQUEST_MEMORY}, {REQUEST_DISK}) aren't present
+            with valid values.
+
+        Returns a a new dictionary with the altered keys. If any key is not present no action is
+        taken for that key.
+        """
+        # TODO could support more units and convert as necessary (see checker funcs at start
+        # of module). YAGNI for now.
+        if reqs is None:
+            reqs = {}
+        ret = {}
+        for key in [CLIENT_GROUP, REQUEST_CPUS, REQUEST_MEMORY, REQUEST_DISK,
+                    CLIENT_GROUP_REGEX, DEBUG_MODE]:
+            if not cls._has_value(reqs.get(key)):
+                if require_all_resources and key in _RESOURCES:
+                    raise IncorrectParamsException(
+                        f"Missing {key} key in job requirements from {source}"
+                    )
+            else:
+                ret[key] = _KEY_CHECKERS[key](reqs.get(key), source)
+        return ret
+
+    @classmethod
+    def _has_value(cls, inc):
+        if inc is None:
+            return False
+        if type(inc) == str and not inc.strip():
+            return False
+        return True

--- a/test/tests_for_utils/job_requirements_resolver_test.py
+++ b/test/tests_for_utils/job_requirements_resolver_test.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for the job requirements resolver.
+"""
+
+from enum import Enum
+from pytest import raises
+from execution_engine2.utils.job_requirements_resolver import JobRequirementsResolver
+from execution_engine2.exceptions import IncorrectParamsException
+from utils_shared.test_utils import assert_exception_correct
+
+
+def test_normalize_job_reqs_minimal():
+    assert JobRequirementsResolver.normalize_job_reqs(None, "mysource") == {}
+    assert JobRequirementsResolver.normalize_job_reqs({}, "mysource") == {}
+    assert JobRequirementsResolver.normalize_job_reqs({
+        "request_cpus": None,
+        "request_memory": None,
+        "request_disk": None,
+        "client_group": None,
+        "client_group_regex": None,
+        "debug_mode": None,
+        "expect_noop": " fooo  "
+    }, "source") == {}
+    assert JobRequirementsResolver.normalize_job_reqs({
+        "request_cpus": "   \t   ",
+        "request_memory": "   \t   ",
+        "request_disk": "   \t   ",
+        "client_group": "    \t    ",
+        "client_group_regex": "   \t   ",
+        "debug_mode": "   \t   ",
+        "expect_noop": " fooo  "
+    }, "source") == {}
+
+
+def test_normalize_job_reqs_minimal_require_all():
+    assert JobRequirementsResolver.normalize_job_reqs({
+        "request_cpus": 1,
+        "request_memory": 1,
+        "request_disk": 1,
+        "client_group": "foo",
+    },
+        "source",
+        True) == {
+        "request_cpus": 1,
+        "request_memory": 1,
+        "request_disk": 1,
+        "client_group": "foo",
+    }
+
+
+def test_normalize_job_reqs_maximal_ints():
+    assert JobRequirementsResolver.normalize_job_reqs(
+        {
+            "request_cpus": 56,
+            "request_memory": 200,
+            "request_disk": 7000,
+            "client_group": "     njs    ",
+            "client_group_regex": 1,
+            "debug_mode": -1,
+            "expect_noop": 1
+        },
+        "mysource",
+    ) == {
+        "request_cpus": 56,
+        "request_memory": 200,
+        "request_disk": 7000,
+        "client_group": "njs",
+        "client_group_regex": True,
+        "debug_mode": True,
+    }
+
+
+def test_normalize_job_reqs_maximal_strings():
+    assert JobRequirementsResolver.normalize_job_reqs(
+        {
+            "request_cpus": "   56   ",
+            "request_memory": "   201     ",
+            "request_disk": "    \t   7000    ",
+            "client_group": "     njs    ",
+            "client_group_regex": "    False    ",
+            "debug_mode": "     true   \t   ",
+            "expect_noop": 1
+        },
+        "mysource",
+    ) == {
+        "request_cpus": 56,
+        "request_memory": 201,
+        "request_disk": 7000,
+        "client_group": "njs",
+        "client_group_regex": False,
+        "debug_mode": True,
+    }
+
+
+def test_normalize_job_reqs_memory():
+    for mem in [2000, "2000    ", "   2000M   ", "2000MB"]:
+        assert JobRequirementsResolver.normalize_job_reqs(
+            {"request_memory": mem}, "s") == {"request_memory": 2000}
+
+
+def test_normalize_job_reqs_disk():
+    for disk in [6000, "6000", "   6000GB   "]:
+        assert JobRequirementsResolver.normalize_job_reqs(
+            {"request_disk": disk}, "s") == {"request_disk": 6000}
+
+
+def test_normalize_job_reqs_bools_true():
+    for b in [True, 1, -1, 100, -100, "    True   ", "   true"]:
+        assert JobRequirementsResolver.normalize_job_reqs(
+            {"client_group_regex": b, "debug_mode": b}, "s") == {
+                "client_group_regex": True, "debug_mode": True}
+
+
+def test_normalize_job_reqs_bools_False():
+    for b in [False, 0, "    False   ", "   false"]:
+        assert JobRequirementsResolver.normalize_job_reqs(
+            {"client_group_regex": b, "debug_mode": b}, "s") == {
+                "client_group_regex": False, "debug_mode": False}
+
+
+def test_normalize_job_reqs_fail_client_group():
+    _normalize_job_reqs_fail({"client_group": []}, "src", False, IncorrectParamsException(
+        "Found illegal client group '[]' in job requirements from src"))
+    _normalize_job_reqs_fail({"client_group": "njs=true"}, "src2", False, IncorrectParamsException(
+        "Found illegal client group 'njs=true' in job requirements from src2"))
+
+
+def test_normalize_job_reqs_fail_cpu():
+    _normalize_job_reqs_fail({"request_cpus": 8.4}, "src3", False, IncorrectParamsException(
+        "Found illegal cpu request '8.4' in job requirements from src3"))
+    _normalize_job_reqs_fail({"request_cpus": "26M"}, "src4", False, IncorrectParamsException(
+        "Found illegal cpu request '26M' in job requirements from src4"))
+
+
+def test_normalize_job_reqs_fail_mem():
+    _normalize_job_reqs_fail({"request_memory": 3.2}, "src5", False, IncorrectParamsException(
+        "Found illegal memory request '3.2' in job requirements from src5"))
+    _normalize_job_reqs_fail({"request_memory": {}}, "src5", False, IncorrectParamsException(
+        "Found illegal memory request '{}' in job requirements from src5"))
+    _normalize_job_reqs_fail({"request_memory": "26G"}, "src6", False, IncorrectParamsException(
+        "Found illegal memory request '26G' in job requirements from src6"))
+
+
+def test_normalize_job_reqs_fail_disk():
+    _normalize_job_reqs_fail({"request_disk": 6.5}, "src", False, IncorrectParamsException(
+        "Found illegal disk request '6.5' in job requirements from src"))
+    _normalize_job_reqs_fail({"request_disk": set()}, "src", False, IncorrectParamsException(
+        "Found illegal disk request 'set()' in job requirements from src"))
+    _normalize_job_reqs_fail({"request_disk": "26M"}, "src", False, IncorrectParamsException(
+        "Found illegal disk request '26M' in job requirements from src"))
+
+
+def test_normalize_job_reqs_fail_regex():
+    _normalize_job_reqs_fail(
+        {"client_group_regex": 92.4}, "src", False, IncorrectParamsException(
+            "Found illegal client group regex '92.4' in job requirements from src"))
+    _normalize_job_reqs_fail(
+        {"client_group_regex": Enum}, "src", False, IncorrectParamsException(
+            "Found illegal client group regex '<enum 'Enum'>' in job requirements from src"))
+    _normalize_job_reqs_fail(
+        {"client_group_regex": "truthy"}, "src", False, IncorrectParamsException(
+            "Found illegal client group regex 'truthy' in job requirements from src"))
+
+
+def test_normalize_job_reqs_fail_debug():
+    _normalize_job_reqs_fail({"debug_mode": 9.5}, "src", False, IncorrectParamsException(
+        "Found illegal debug mode '9.5' in job requirements from src"))
+    _normalize_job_reqs_fail({"debug_mode": int}, "src", False, IncorrectParamsException(
+        "Found illegal debug mode '<class 'int'>' in job requirements from src"))
+    _normalize_job_reqs_fail({"debug_mode": " yep "}, "src", False, IncorrectParamsException(
+        "Found illegal debug mode ' yep ' in job requirements from src"))
+
+
+def test_normalize_job_reqs_fail_require_all():
+    reqs_all = {
+        "request_cpus": 56,
+        "request_memory": 200,
+        "request_disk": 7000,
+        "client_group": "njs",
+    }
+    for k in ["request_cpus", "request_memory", "request_disk", "client_group"]:
+        r = dict(reqs_all)
+        del r[k]
+        _normalize_job_reqs_fail(r, "mysrc", True, IncorrectParamsException(
+            f"Missing {k} key in job requirements from mysrc"))
+
+
+def _normalize_job_reqs_fail(reqs, source, req_all_res, expected):
+    with raises(Exception) as got:
+        JobRequirementsResolver.normalize_job_reqs(reqs, source, req_all_res)
+    assert_exception_correct(got.value, expected)

--- a/test/tests_for_utils/job_requirements_resolver_test.py
+++ b/test/tests_for_utils/job_requirements_resolver_test.py
@@ -12,35 +12,49 @@ from utils_shared.test_utils import assert_exception_correct
 def test_normalize_job_reqs_minimal():
     assert JobRequirementsResolver.normalize_job_reqs(None, "mysource") == {}
     assert JobRequirementsResolver.normalize_job_reqs({}, "mysource") == {}
-    assert JobRequirementsResolver.normalize_job_reqs({
-        "request_cpus": None,
-        "request_memory": None,
-        "request_disk": None,
-        "client_group": None,
-        "client_group_regex": None,
-        "debug_mode": None,
-        "expect_noop": " fooo  "
-    }, "source") == {}
-    assert JobRequirementsResolver.normalize_job_reqs({
-        "request_cpus": "   \t   ",
-        "request_memory": "   \t   ",
-        "request_disk": "   \t   ",
-        "client_group": "    \t    ",
-        "client_group_regex": "   \t   ",
-        "debug_mode": "   \t   ",
-        "expect_noop": " fooo  "
-    }, "source") == {}
+    assert (
+        JobRequirementsResolver.normalize_job_reqs(
+            {
+                "request_cpus": None,
+                "request_memory": None,
+                "request_disk": None,
+                "client_group": None,
+                "client_group_regex": None,
+                "debug_mode": None,
+                "expect_noop": " fooo  ",
+            },
+            "source",
+        )
+        == {}
+    )
+    assert (
+        JobRequirementsResolver.normalize_job_reqs(
+            {
+                "request_cpus": "   \t   ",
+                "request_memory": "   \t   ",
+                "request_disk": "   \t   ",
+                "client_group": "    \t    ",
+                "client_group_regex": "   \t   ",
+                "debug_mode": "   \t   ",
+                "expect_noop": " fooo  ",
+            },
+            "source",
+        )
+        == {}
+    )
 
 
 def test_normalize_job_reqs_minimal_require_all():
-    assert JobRequirementsResolver.normalize_job_reqs({
-        "request_cpus": 1,
-        "request_memory": 1,
-        "request_disk": 1,
-        "client_group": "foo",
-    },
+    assert JobRequirementsResolver.normalize_job_reqs(
+        {
+            "request_cpus": 1,
+            "request_memory": 1,
+            "request_disk": 1,
+            "client_group": "foo",
+        },
         "source",
-        True) == {
+        True,
+    ) == {
         "request_cpus": 1,
         "request_memory": 1,
         "request_disk": 1,
@@ -57,7 +71,7 @@ def test_normalize_job_reqs_maximal_ints():
             "client_group": "     njs    ",
             "client_group_regex": 1,
             "debug_mode": -1,
-            "expect_noop": 1
+            "expect_noop": 1,
         },
         "mysource",
     ) == {
@@ -79,7 +93,7 @@ def test_normalize_job_reqs_maximal_strings():
             "client_group": "     njs    ",
             "client_group_regex": "    False    ",
             "debug_mode": "     true   \t   ",
-            "expect_noop": 1
+            "expect_noop": 1,
         },
         "mysource",
     ) == {
@@ -95,80 +109,175 @@ def test_normalize_job_reqs_maximal_strings():
 def test_normalize_job_reqs_memory():
     for mem in [2000, "2000    ", "   2000M   ", "2000MB"]:
         assert JobRequirementsResolver.normalize_job_reqs(
-            {"request_memory": mem}, "s") == {"request_memory": 2000}
+            {"request_memory": mem}, "s"
+        ) == {"request_memory": 2000}
 
 
 def test_normalize_job_reqs_disk():
     for disk in [6000, "6000", "   6000GB   "]:
         assert JobRequirementsResolver.normalize_job_reqs(
-            {"request_disk": disk}, "s") == {"request_disk": 6000}
+            {"request_disk": disk}, "s"
+        ) == {"request_disk": 6000}
 
 
 def test_normalize_job_reqs_bools_true():
     for b in [True, 1, -1, 100, -100, "    True   ", "   true"]:
         assert JobRequirementsResolver.normalize_job_reqs(
-            {"client_group_regex": b, "debug_mode": b}, "s") == {
-                "client_group_regex": True, "debug_mode": True}
+            {"client_group_regex": b, "debug_mode": b}, "s"
+        ) == {"client_group_regex": True, "debug_mode": True}
 
 
 def test_normalize_job_reqs_bools_False():
     for b in [False, 0, "    False   ", "   false"]:
         assert JobRequirementsResolver.normalize_job_reqs(
-            {"client_group_regex": b, "debug_mode": b}, "s") == {
-                "client_group_regex": False, "debug_mode": False}
+            {"client_group_regex": b, "debug_mode": b}, "s"
+        ) == {"client_group_regex": False, "debug_mode": False}
 
 
 def test_normalize_job_reqs_fail_client_group():
-    _normalize_job_reqs_fail({"client_group": []}, "src", False, IncorrectParamsException(
-        "Found illegal client group '[]' in job requirements from src"))
-    _normalize_job_reqs_fail({"client_group": "njs=true"}, "src2", False, IncorrectParamsException(
-        "Found illegal client group 'njs=true' in job requirements from src2"))
+    _normalize_job_reqs_fail(
+        {"client_group": []},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal client group '[]' in job requirements from src"
+        ),
+    )
+    _normalize_job_reqs_fail(
+        {"client_group": "njs=true"},
+        "src2",
+        False,
+        IncorrectParamsException(
+            "Found illegal client group 'njs=true' in job requirements from src2"
+        ),
+    )
 
 
 def test_normalize_job_reqs_fail_cpu():
-    _normalize_job_reqs_fail({"request_cpus": 8.4}, "src3", False, IncorrectParamsException(
-        "Found illegal cpu request '8.4' in job requirements from src3"))
-    _normalize_job_reqs_fail({"request_cpus": "26M"}, "src4", False, IncorrectParamsException(
-        "Found illegal cpu request '26M' in job requirements from src4"))
+    _normalize_job_reqs_fail(
+        {"request_cpus": 8.4},
+        "src3",
+        False,
+        IncorrectParamsException(
+            "Found illegal cpu request '8.4' in job requirements from src3"
+        ),
+    )
+    _normalize_job_reqs_fail(
+        {"request_cpus": "26M"},
+        "src4",
+        False,
+        IncorrectParamsException(
+            "Found illegal cpu request '26M' in job requirements from src4"
+        ),
+    )
 
 
 def test_normalize_job_reqs_fail_mem():
-    _normalize_job_reqs_fail({"request_memory": 3.2}, "src5", False, IncorrectParamsException(
-        "Found illegal memory request '3.2' in job requirements from src5"))
-    _normalize_job_reqs_fail({"request_memory": {}}, "src5", False, IncorrectParamsException(
-        "Found illegal memory request '{}' in job requirements from src5"))
-    _normalize_job_reqs_fail({"request_memory": "26G"}, "src6", False, IncorrectParamsException(
-        "Found illegal memory request '26G' in job requirements from src6"))
+    _normalize_job_reqs_fail(
+        {"request_memory": 3.2},
+        "src5",
+        False,
+        IncorrectParamsException(
+            "Found illegal memory request '3.2' in job requirements from src5"
+        ),
+    )
+    _normalize_job_reqs_fail(
+        {"request_memory": {}},
+        "src5",
+        False,
+        IncorrectParamsException(
+            "Found illegal memory request '{}' in job requirements from src5"
+        ),
+    )
+    _normalize_job_reqs_fail(
+        {"request_memory": "26G"},
+        "src6",
+        False,
+        IncorrectParamsException(
+            "Found illegal memory request '26G' in job requirements from src6"
+        ),
+    )
 
 
 def test_normalize_job_reqs_fail_disk():
-    _normalize_job_reqs_fail({"request_disk": 6.5}, "src", False, IncorrectParamsException(
-        "Found illegal disk request '6.5' in job requirements from src"))
-    _normalize_job_reqs_fail({"request_disk": set()}, "src", False, IncorrectParamsException(
-        "Found illegal disk request 'set()' in job requirements from src"))
-    _normalize_job_reqs_fail({"request_disk": "26M"}, "src", False, IncorrectParamsException(
-        "Found illegal disk request '26M' in job requirements from src"))
+    _normalize_job_reqs_fail(
+        {"request_disk": 6.5},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal disk request '6.5' in job requirements from src"
+        ),
+    )
+    _normalize_job_reqs_fail(
+        {"request_disk": set()},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal disk request 'set()' in job requirements from src"
+        ),
+    )
+    _normalize_job_reqs_fail(
+        {"request_disk": "26M"},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal disk request '26M' in job requirements from src"
+        ),
+    )
 
 
 def test_normalize_job_reqs_fail_regex():
     _normalize_job_reqs_fail(
-        {"client_group_regex": 92.4}, "src", False, IncorrectParamsException(
-            "Found illegal client group regex '92.4' in job requirements from src"))
+        {"client_group_regex": 92.4},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal client group regex '92.4' in job requirements from src"
+        ),
+    )
     _normalize_job_reqs_fail(
-        {"client_group_regex": Enum}, "src", False, IncorrectParamsException(
-            "Found illegal client group regex '<enum 'Enum'>' in job requirements from src"))
+        {"client_group_regex": Enum},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal client group regex '<enum 'Enum'>' in job requirements from src"
+        ),
+    )
     _normalize_job_reqs_fail(
-        {"client_group_regex": "truthy"}, "src", False, IncorrectParamsException(
-            "Found illegal client group regex 'truthy' in job requirements from src"))
+        {"client_group_regex": "truthy"},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal client group regex 'truthy' in job requirements from src"
+        ),
+    )
 
 
 def test_normalize_job_reqs_fail_debug():
-    _normalize_job_reqs_fail({"debug_mode": 9.5}, "src", False, IncorrectParamsException(
-        "Found illegal debug mode '9.5' in job requirements from src"))
-    _normalize_job_reqs_fail({"debug_mode": int}, "src", False, IncorrectParamsException(
-        "Found illegal debug mode '<class 'int'>' in job requirements from src"))
-    _normalize_job_reqs_fail({"debug_mode": " yep "}, "src", False, IncorrectParamsException(
-        "Found illegal debug mode ' yep ' in job requirements from src"))
+    _normalize_job_reqs_fail(
+        {"debug_mode": 9.5},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal debug mode '9.5' in job requirements from src"
+        ),
+    )
+    _normalize_job_reqs_fail(
+        {"debug_mode": int},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal debug mode '<class 'int'>' in job requirements from src"
+        ),
+    )
+    _normalize_job_reqs_fail(
+        {"debug_mode": " yep "},
+        "src",
+        False,
+        IncorrectParamsException(
+            "Found illegal debug mode ' yep ' in job requirements from src"
+        ),
+    )
 
 
 def test_normalize_job_reqs_fail_require_all():
@@ -181,8 +290,12 @@ def test_normalize_job_reqs_fail_require_all():
     for k in ["request_cpus", "request_memory", "request_disk", "client_group"]:
         r = dict(reqs_all)
         del r[k]
-        _normalize_job_reqs_fail(r, "mysrc", True, IncorrectParamsException(
-            f"Missing {k} key in job requirements from mysrc"))
+        _normalize_job_reqs_fail(
+            r,
+            "mysrc",
+            True,
+            IncorrectParamsException(f"Missing {k} key in job requirements from mysrc"),
+        )
 
 
 def _normalize_job_reqs_fail(reqs, source, req_all_res, expected):


### PR DESCRIPTION
# Description of PR purpose/changes

First step of adding a class to determine the requirements of a job from 3 sources - user input, the catalog record for the method, and the EE2 configuration file.

This PR adds a method to normalize job requirements given in `dict` format - e.g. parse strings to ints, etc. This is particularly useful for the catalog and config file sources since the former can present as a CSV string and the latter is an ini file, so all values are strings.

Expect 4 total PRs to complete the requirements resolver class.

# Jira Ticket / Github Issue #
- [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
