### PR TITLE
DATAUP-389 - add a job requirements resolver, pt 2 of 4

### DIFF
--- a/test/tests_for_utils/job_requirements_resolver_test.py
+++ b/test/tests_for_utils/job_requirements_resolver_test.py
@@ -4,7 +4,10 @@ Unit tests for the job requirements resolver.
 
 from enum import Enum
 from pytest import raises
-from execution_engine2.utils.job_requirements_resolver import JobRequirementsResolver
+from execution_engine2.utils.job_requirements_resolver import (
+    JobRequirementsResolver,
+    RequirementsType,
+)
 from execution_engine2.exceptions import IncorrectParamsException
 from utils_shared.test_utils import assert_exception_correct
 
@@ -301,4 +304,74 @@ def test_normalize_job_reqs_fail_require_all():
 def _normalize_job_reqs_fail(reqs, source, req_all_res, expected):
     with raises(Exception) as got:
         JobRequirementsResolver.normalize_job_reqs(reqs, source, req_all_res)
+    assert_exception_correct(got.value, expected)
+
+
+def test_get_requirements_type_standard():
+    grt = JobRequirementsResolver.get_requirements_type
+    assert grt() == RequirementsType.STANDARD
+    assert grt(None, None, None, None, None, None, None, None, None) == RequirementsType.STANDARD
+    assert grt(None, None, None, None, None, None, False, {}, False) == RequirementsType.STANDARD
+
+
+def test_get_requirements_type_processing():
+    grt = JobRequirementsResolver.get_requirements_type
+    assert grt(cpus=4) == RequirementsType.PROCESSING
+    assert grt(memory_MB=26) == RequirementsType.PROCESSING
+    assert grt(disk_GB=78) == RequirementsType.PROCESSING
+    assert grt(client_group="foo") == RequirementsType.PROCESSING
+    assert grt(client_group_regex=False) == RequirementsType.PROCESSING
+    assert grt(client_group_regex=True) == RequirementsType.PROCESSING
+    assert grt(ignore_concurrency_limits=True) == RequirementsType.PROCESSING
+    assert grt(scheduler_requirements={"a": "b"}) == RequirementsType.PROCESSING
+    assert grt(debug_mode=True) == RequirementsType.PROCESSING
+
+    assert grt(
+        cpus=4,
+        memory_MB=2,
+        disk_GB=8,
+        client_group="yay",
+        client_group_regex=True,
+        ignore_concurrency_limits=True,
+        debug_mode=True,
+    ) == RequirementsType.PROCESSING
+
+
+def test_get_requirements_type_billing():
+    grt = JobRequirementsResolver.get_requirements_type
+    assert grt(bill_to_user="foo") == RequirementsType.BILLING
+
+    assert grt(
+        cpus=4,
+        memory_MB=2,
+        disk_GB=8,
+        client_group="yay",
+        client_group_regex=True,
+        bill_to_user="can I buy you a drink?",
+        ignore_concurrency_limits=True,
+        debug_mode=True,
+    ) == RequirementsType.BILLING
+
+
+def test_get_requirements_type_fail():
+    # All the illegal requirements testing is delegated to a method outside the code
+    # unit under test, so we just do one test per input to be sure it's hooked up correctly
+    # and delegate more thorough testing to the unit tests for the called method.
+    n = None
+    _grtf = _get_requirements_type_fail
+    _grtf(0, n, n, n, n, IncorrectParamsException("CPU count must be at least 1"))
+    _grtf(n, 0, n, n, n, IncorrectParamsException("memory in MB must be at least 1"))
+    _grtf(n, n, 0, n, n, IncorrectParamsException("disk space in GB must be at least 1"))
+    _grtf(n, n, n, "    \t   ", n, IncorrectParamsException(
+        "Missing input parameter: client_group"))
+    _grtf(n, n, n, n, "   \bfoo   ", IncorrectParamsException(
+        "bill_to_user contains control characters"))
+    # note there are no invalid values for client_group_regex, ignore_concurrentcy_limits,
+    # and debug_mode
+
+
+def _get_requirements_type_fail(cpus, mem, disk, cg, btu, expected):
+    with raises(Exception) as got:
+        JobRequirementsResolver.get_requirements_type(
+            cpus, mem, disk, cg, False, btu, False, False)
     assert_exception_correct(got.value, expected)

--- a/test/tests_for_utils/job_requirements_resolver_test.py
+++ b/test/tests_for_utils/job_requirements_resolver_test.py
@@ -310,8 +310,14 @@ def _normalize_job_reqs_fail(reqs, source, req_all_res, expected):
 def test_get_requirements_type_standard():
     grt = JobRequirementsResolver.get_requirements_type
     assert grt() == RequirementsType.STANDARD
-    assert grt(None, None, None, None, None, None, None, None, None) == RequirementsType.STANDARD
-    assert grt(None, None, None, None, None, None, False, {}, False) == RequirementsType.STANDARD
+    assert (
+        grt(None, None, None, None, None, None, None, None, None)
+        == RequirementsType.STANDARD
+    )
+    assert (
+        grt(None, None, None, None, None, None, False, {}, False)
+        == RequirementsType.STANDARD
+    )
 
 
 def test_get_requirements_type_processing():
@@ -326,31 +332,37 @@ def test_get_requirements_type_processing():
     assert grt(scheduler_requirements={"a": "b"}) == RequirementsType.PROCESSING
     assert grt(debug_mode=True) == RequirementsType.PROCESSING
 
-    assert grt(
-        cpus=4,
-        memory_MB=2,
-        disk_GB=8,
-        client_group="yay",
-        client_group_regex=True,
-        ignore_concurrency_limits=True,
-        debug_mode=True,
-    ) == RequirementsType.PROCESSING
+    assert (
+        grt(
+            cpus=4,
+            memory_MB=2,
+            disk_GB=8,
+            client_group="yay",
+            client_group_regex=True,
+            ignore_concurrency_limits=True,
+            debug_mode=True,
+        )
+        == RequirementsType.PROCESSING
+    )
 
 
 def test_get_requirements_type_billing():
     grt = JobRequirementsResolver.get_requirements_type
     assert grt(bill_to_user="foo") == RequirementsType.BILLING
 
-    assert grt(
-        cpus=4,
-        memory_MB=2,
-        disk_GB=8,
-        client_group="yay",
-        client_group_regex=True,
-        bill_to_user="can I buy you a drink?",
-        ignore_concurrency_limits=True,
-        debug_mode=True,
-    ) == RequirementsType.BILLING
+    assert (
+        grt(
+            cpus=4,
+            memory_MB=2,
+            disk_GB=8,
+            client_group="yay",
+            client_group_regex=True,
+            bill_to_user="can I buy you a drink?",
+            ignore_concurrency_limits=True,
+            debug_mode=True,
+        )
+        == RequirementsType.BILLING
+    )
 
 
 def test_get_requirements_type_fail():
@@ -361,11 +373,25 @@ def test_get_requirements_type_fail():
     _grtf = _get_requirements_type_fail
     _grtf(0, n, n, n, n, IncorrectParamsException("CPU count must be at least 1"))
     _grtf(n, 0, n, n, n, IncorrectParamsException("memory in MB must be at least 1"))
-    _grtf(n, n, 0, n, n, IncorrectParamsException("disk space in GB must be at least 1"))
-    _grtf(n, n, n, "    \t   ", n, IncorrectParamsException(
-        "Missing input parameter: client_group"))
-    _grtf(n, n, n, n, "   \bfoo   ", IncorrectParamsException(
-        "bill_to_user contains control characters"))
+    _grtf(
+        n, n, 0, n, n, IncorrectParamsException("disk space in GB must be at least 1")
+    )
+    _grtf(
+        n,
+        n,
+        n,
+        "    \t   ",
+        n,
+        IncorrectParamsException("Missing input parameter: client_group"),
+    )
+    _grtf(
+        n,
+        n,
+        n,
+        n,
+        "   \bfoo   ",
+        IncorrectParamsException("bill_to_user contains control characters"),
+    )
     # note there are no invalid values for client_group_regex, ignore_concurrentcy_limits,
     # and debug_mode
 
@@ -373,5 +399,6 @@ def test_get_requirements_type_fail():
 def _get_requirements_type_fail(cpus, mem, disk, cg, btu, expected):
     with raises(Exception) as got:
         JobRequirementsResolver.get_requirements_type(
-            cpus, mem, disk, cg, False, btu, False, False)
+            cpus, mem, disk, cg, False, btu, False, False
+        )
     assert_exception_correct(got.value, expected)


### PR DESCRIPTION
# Description of PR purpose/changes

Determine a requirements type based on job requirements. This will be used
to determine whether a user is allowed to run a job with non-default
requirements based on their ee2 admin status.

*Probably* for now anything other than standard will require write admin but
billing is split out as billing a job to another user seems like a step above
merely specifying how a job is run.

# Jira Ticket / Github Issue #
- [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
