### PR TITLE
DATAUP-389 - add a job requirements resolver, pt 3 of 4

### DIFF
--- a/lib/execution_engine2/sdk/EE2Constants.py
+++ b/lib/execution_engine2/sdk/EE2Constants.py
@@ -9,6 +9,10 @@ from typing import Optional, NamedTuple
 KBASE_CONCIERGE_USERNAME = "kbaseconcierge"
 CONCIERGE_CLIENTGROUP = "kbase_concierge"
 
+EE2_CONFIG_SECTION = "execution_engine2"
+EE2_DEFAULT_SECTION = "DEFAULT"
+EE2_DEFAULT_CLIENT_GROUP = "default_client_group"
+
 # these also probably should be configurable.
 ADMIN_READ_ROLE = "EE2_ADMIN_RO"
 ADMIN_WRITE_ROLE = "EE2_ADMIN"

--- a/lib/execution_engine2/utils/job_requirements_resolver.py
+++ b/lib/execution_engine2/utils/job_requirements_resolver.py
@@ -17,7 +17,7 @@ from execution_engine2.sdk.job_submission_parameters import JobRequirements
 from execution_engine2.sdk.EE2Constants import (
     EE2_CONFIG_SECTION,
     EE2_DEFAULT_SECTION,
-    EE2_DEFAULT_CLIENT_GROUP
+    EE2_DEFAULT_CLIENT_GROUP,
 )
 from execution_engine2.exceptions import IncorrectParamsException
 
@@ -165,17 +165,26 @@ class JobRequirementsResolver:
         config.read_file(_not_falsy(cfgfile, "cfgfile"))
         self._default_client_group = _check_string(
             config.get(
-                section=EE2_DEFAULT_SECTION, option=EE2_DEFAULT_CLIENT_GROUP, fallback=None),
-            f"value for {EE2_DEFAULT_SECTION}.{EE2_DEFAULT_CLIENT_GROUP} in deployment config file"
+                section=EE2_DEFAULT_SECTION,
+                option=EE2_DEFAULT_CLIENT_GROUP,
+                fallback=None,
+            ),
+            f"value for {EE2_DEFAULT_SECTION}.{EE2_DEFAULT_CLIENT_GROUP} in deployment config file",
         )
         self._clientgroup_default_configs = self._build_config(config)
         if self._default_client_group not in self._clientgroup_default_configs:
-            raise ValueError("No deployment configuration entry for default "
-                             + f"client group '{self._default_client_group}'")
-        if (self._override_client_group
-                and self._override_client_group not in self._clientgroup_default_configs):
-            raise ValueError("No deployment configuration entry for override "
-                             + f"client group '{self._override_client_group}'")
+            raise ValueError(
+                "No deployment configuration entry for default "
+                + f"client group '{self._default_client_group}'"
+            )
+        if (
+            self._override_client_group
+            and self._override_client_group not in self._clientgroup_default_configs
+        ):
+            raise ValueError(
+                "No deployment configuration entry for override "
+                + f"client group '{self._override_client_group}'"
+            )
 
     def _build_config(self, config):
         ret = {}
@@ -188,7 +197,7 @@ class JobRequirementsResolver:
                 ret[sec] = self.normalize_job_reqs(
                     reqspec,
                     f"section '{sec}' of the deployment configuration",
-                    require_all_resources=True
+                    require_all_resources=True,
                 )
         return ret
 
@@ -211,7 +220,9 @@ class JobRequirementsResolver:
         """
         return self._clientgroup_default_configs.keys()
 
-    def get_configured_client_group_spec(self, clientgroup: str) -> Dict[str, Union[int, str]]:
+    def get_configured_client_group_spec(
+        self, clientgroup: str
+    ) -> Dict[str, Union[int, str]]:
         f"""
         Get the client ground specification in normalized format. Includes the {CLIENT_GROUP},
         {REQUEST_CPUS}, {REQUEST_MEMORY}, and {REQUEST_DISK} keys. May, but usually will not,

--- a/lib/execution_engine2/utils/job_requirements_resolver.py
+++ b/lib/execution_engine2/utils/job_requirements_resolver.py
@@ -224,7 +224,7 @@ class JobRequirementsResolver:
         self, clientgroup: str
     ) -> Dict[str, Union[int, str]]:
         f"""
-        Get the client ground specification in normalized format. Includes the {CLIENT_GROUP},
+        Get the client group specification in normalized format. Includes the {CLIENT_GROUP},
         {REQUEST_CPUS}, {REQUEST_MEMORY}, and {REQUEST_DISK} keys. May, but usually will not,
         include the {DEBUG_MODE} and {CLIENT_GROUP_REGEX} keys.
         """

--- a/test/tests_for_utils/job_requirements_resolver_test.py
+++ b/test/tests_for_utils/job_requirements_resolver_test.py
@@ -432,6 +432,7 @@ def _get_simple_deploy_spec_file_obj():
         """
     )
 
+
 # Note the constructor uses the normalization class method under the hood for normalizing
 # the EE2 config file client groups. As such, we don't duplicate the testing of that method
 # here other than some spot checks. If the constructor changes significantly more
@@ -451,7 +452,7 @@ def test_init():
         "request_cpus": 4,
         "request_memory": 2000,
         "request_disk": 100,
-        "client_group": "cg1"
+        "client_group": "cg1",
     }
 
     assert jrr.get_configured_client_group_spec("cg2") == {
@@ -460,7 +461,7 @@ def test_init():
         "request_disk": 32,
         "client_group": "cg2",
         "debug_mode": True,
-        "client_group_regex": False
+        "client_group_regex": False,
     }
 
 
@@ -478,20 +479,36 @@ def test_init_with_override():
 
 def test_init_fail_missing_input():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    _init_fail(None, _get_simple_deploy_spec_file_obj(), None, ValueError(
-        "catalog cannot be a value that evaluates to false"))
-    _init_fail(catalog, None, None, ValueError(
-        "cfgfile cannot be a value that evaluates to false"))
-    _init_fail(catalog, [], None, ValueError(
-        "cfgfile cannot be a value that evaluates to false"))
+    _init_fail(
+        None,
+        _get_simple_deploy_spec_file_obj(),
+        None,
+        ValueError("catalog cannot be a value that evaluates to false"),
+    )
+    _init_fail(
+        catalog,
+        None,
+        None,
+        ValueError("cfgfile cannot be a value that evaluates to false"),
+    )
+    _init_fail(
+        catalog,
+        [],
+        None,
+        ValueError("cfgfile cannot be a value that evaluates to false"),
+    )
 
 
 def test_init_fail_no_override_in_config():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
 
     spec = _get_simple_deploy_spec_file_obj()
-    _init_fail(catalog, spec, "cg3", ValueError(
-        "No deployment configuration entry for override client group 'cg3'"))
+    _init_fail(
+        catalog,
+        spec,
+        "cg3",
+        ValueError("No deployment configuration entry for override client group 'cg3'"),
+    )
 
 
 def test_init_fail_default_config_error():
@@ -504,9 +521,15 @@ def test_init_fail_default_config_error():
         request_disk = 100GB
         """
 
-    _init_fail(catalog, StringIO(shared_spec), None, IncorrectParamsException(
-        "Missing input parameter: value for DEFAULT.default_client_group in deployment "
-        + "config file"))
+    _init_fail(
+        catalog,
+        StringIO(shared_spec),
+        None,
+        IncorrectParamsException(
+            "Missing input parameter: value for DEFAULT.default_client_group in deployment "
+            + "config file"
+        ),
+    )
 
     spec = StringIO(
         shared_spec
@@ -515,9 +538,15 @@ def test_init_fail_default_config_error():
         foo = bar
         """
     )
-    _init_fail(catalog, spec, None, IncorrectParamsException(
-        "Missing input parameter: value for DEFAULT.default_client_group in deployment "
-        + "config file"))
+    _init_fail(
+        catalog,
+        spec,
+        None,
+        IncorrectParamsException(
+            "Missing input parameter: value for DEFAULT.default_client_group in deployment "
+            + "config file"
+        ),
+    )
 
     spec = StringIO(
         shared_spec
@@ -526,8 +555,12 @@ def test_init_fail_default_config_error():
         default_client_group = njrs
         """
     )
-    _init_fail(catalog, spec, None, ValueError(
-        "No deployment configuration entry for default client group 'njrs'"))
+    _init_fail(
+        catalog,
+        spec,
+        None,
+        ValueError("No deployment configuration entry for default client group 'njrs'"),
+    )
 
 
 def test_init_fail_bad_config():
@@ -538,35 +571,62 @@ def test_init_fail_bad_config():
         default_client_group = njs
         """
 
-    spec = shared_spec + """
+    spec = (
+        shared_spec
+        + """
         [njs]
         request_memory = 2000M
         request_disk = 100GB
         """
+    )
 
-    _init_fail(catalog, StringIO(spec), None, IncorrectParamsException(
-        "Missing request_cpus key in job requirements from section 'njs' of the "
-        + "deployment configuration"))
+    _init_fail(
+        catalog,
+        StringIO(spec),
+        None,
+        IncorrectParamsException(
+            "Missing request_cpus key in job requirements from section 'njs' of the "
+            + "deployment configuration"
+        ),
+    )
 
-    spec = shared_spec + """
+    spec = (
+        shared_spec
+        + """
         [njs]
         request_cpus = 4
         request_disk = 100GB
         """
+    )
 
-    _init_fail(catalog, StringIO(spec), None, IncorrectParamsException(
-        "Missing request_memory key in job requirements from section 'njs' of the "
-        + "deployment configuration"))
+    _init_fail(
+        catalog,
+        StringIO(spec),
+        None,
+        IncorrectParamsException(
+            "Missing request_memory key in job requirements from section 'njs' of the "
+            + "deployment configuration"
+        ),
+    )
 
-    spec = shared_spec + """
+    spec = (
+        shared_spec
+        + """
         [njs]
         request_cpus = 4
         request_memory = 2000M
         """
+    )
 
-    _init_fail(catalog, StringIO(spec), None, IncorrectParamsException(
-        "Missing request_disk key in job requirements from section 'njs' of the "
-        + "deployment configuration"))
+    _init_fail(
+        catalog,
+        StringIO(spec),
+        None,
+        IncorrectParamsException(
+            "Missing request_disk key in job requirements from section 'njs' of the "
+            + "deployment configuration"
+        ),
+    )
 
 
 def _init_fail(catalog, spec, override, expected):
@@ -582,4 +642,6 @@ def test_get_configured_client_group_spec_fail():
 
     with raises(Exception) as got:
         jrr.get_configured_client_group_spec("cg4")
-    assert_exception_correct(got.value, ValueError("Client group 'cg4' is not configured"))
+    assert_exception_correct(
+        got.value, ValueError("Client group 'cg4' is not configured")
+    )


### PR DESCRIPTION
# Description of PR purpose/changes

Adds the constructor for the job resolver and tests spec parsing for default job requirements values. The next (and last for the resolver module) PR will add the resolution code itself.

# Jira Ticket / Github Issue #
- [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k+ warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
