### PR TITLE
DATAUP-389 - add a job requirements resolver, pt 4 of 4

### DIFF
--- a/lib/execution_engine2/sdk/job_submission_parameters.py
+++ b/lib/execution_engine2/sdk/job_submission_parameters.py
@@ -87,9 +87,9 @@ class JobRequirements:
         client_group: str = None,
         client_group_regex: Union[bool, None] = None,
         bill_to_user: str = None,
-        ignore_concurrency_limits: bool = False,
+        ignore_concurrency_limits: Union[bool, None] = None,
         scheduler_requirements: Dict[str, str] = None,
-        debug_mode: bool = False,
+        debug_mode: Union[bool, None] = None,
     ):
         """
         Test that a set of parameters are legal and returns normalized parmeters.
@@ -124,9 +124,9 @@ class JobRequirements:
             client_group,
             None if client_group_regex is None else bool(client_group_regex),
             _check_string(bill_to_user, "bill_to_user", optional=True),
-            bool(ignore_concurrency_limits),
+            None if ignore_concurrency_limits is None else bool(ignore_concurrency_limits),
             cls._check_scheduler_requirements(scheduler_requirements),
-            bool(debug_mode),
+            None if debug_mode is None else bool(debug_mode),
         )
 
     def _params(self):
@@ -141,6 +141,9 @@ class JobRequirements:
             self.scheduler_requirements,
             self.debug_mode,
         )
+
+    def __repr__(self):
+        return str(self._params())
 
     def __eq__(self, other):
         if type(self) == type(other):

--- a/lib/execution_engine2/sdk/job_submission_parameters.py
+++ b/lib/execution_engine2/sdk/job_submission_parameters.py
@@ -124,7 +124,9 @@ class JobRequirements:
             client_group,
             None if client_group_regex is None else bool(client_group_regex),
             _check_string(bill_to_user, "bill_to_user", optional=True),
-            None if ignore_concurrency_limits is None else bool(ignore_concurrency_limits),
+            None
+            if ignore_concurrency_limits is None
+            else bool(ignore_concurrency_limits),
             cls._check_scheduler_requirements(scheduler_requirements),
             None if debug_mode is None else bool(debug_mode),
         )

--- a/lib/execution_engine2/utils/job_requirements_resolver.py
+++ b/lib/execution_engine2/utils/job_requirements_resolver.py
@@ -30,7 +30,8 @@ CLIENT_GROUP_REGEX = "client_group_regex"
 DEBUG_MODE = "debug_mode"
 _RESOURCES = set([CLIENT_GROUP, REQUEST_CPUS, REQUEST_MEMORY, REQUEST_DISK])
 _ALL_SPECIAL_KEYS = _RESOURCES | set(
-    [CLIENT_GROUP_REGEX, DEBUG_MODE, "bill_to_user", "ignore_concurrency_limits"])
+    [CLIENT_GROUP_REGEX, DEBUG_MODE, "bill_to_user", "ignore_concurrency_limits"]
+)
 
 _CLIENT_GROUPS = "client_groups"
 
@@ -416,7 +417,8 @@ class JobRequirementsResolver:
             f"catalog method {module_name}.{function_name}",
         )
         client_group = self._get_client_group(
-            args[3], cat_reqs.get(CLIENT_GROUP), module_name, function_name)
+            args[3], cat_reqs.get(CLIENT_GROUP), module_name, function_name
+        )
 
         # don't mutate the spec, make a copy
         reqs = dict(self._clientgroup_default_configs[client_group])
@@ -442,14 +444,22 @@ class JobRequirementsResolver:
         )
 
     def _get_client_group(self, user_cg, catalog_cg, module_name, function_name):
-        cg = next(i for i in [
-            self._override_client_group, user_cg, catalog_cg, self._default_client_group]
-            if i is not None)
+        cg = next(
+            i
+            for i in [
+                self._override_client_group,
+                user_cg,
+                catalog_cg,
+                self._default_client_group,
+            ]
+            if i is not None
+        )
         if cg not in self._clientgroup_default_configs:
             if cg == catalog_cg:
                 raise IncorrectParamsException(
                     f"Catalog specified illegal client group '{cg}' for method "
-                    + f"{module_name}.{function_name}")
+                    + f"{module_name}.{function_name}"
+                )
             raise IncorrectParamsException(f"No such clientgroup: {cg}")
         return cg
 
@@ -478,8 +488,10 @@ class JobRequirementsResolver:
             try:
                 rv = json.loads(", ".join(resources_request))
             except ValueError:
-                raise ValueError("Unable to parse JSON client group entry from catalog "
-                                 + f"for method {module_name}.{function_name}")
+                raise ValueError(
+                    "Unable to parse JSON client group entry from catalog "
+                    + f"for method {module_name}.{function_name}"
+                )
             return {k.strip(): rv[k] for k in rv}
         # CSV Format
         rv = {CLIENT_GROUP: resources_request.pop(0)}

--- a/test/tests_for_sdkmr/job_submission_parameters_test.py
+++ b/test/tests_for_sdkmr/job_submission_parameters_test.py
@@ -201,8 +201,7 @@ def _job_req_init_fail(cpus, mem, disk, cgroup, user, reqs, expected):
 
 def test_job_req_check_parameters_no_input():
     n = None
-    f = False
-    assert JobRequirements.check_parameters() == (n, n, n, n, n, n, f, {}, f)
+    assert JobRequirements.check_parameters() == (n, n, n, n, n, n, n, {}, n)
     assert JobRequirements.check_parameters(n, n, n, n, n, n, n, n, n) == (
         n,
         n,
@@ -210,9 +209,9 @@ def test_job_req_check_parameters_no_input():
         n,
         n,
         n,
-        f,
+        n,
         {},
-        f,
+        n,
     )
 
 
@@ -240,13 +239,13 @@ def test_job_req_check_parameters_whitespace_as_user():
             1,
             1,
             "   b   ",
-            False,
+            0,
             " \t  ",
             890,
             {"proc": "x286", "maxmem": "640k"},
-            [],
+            1,
         )
-        == (1, 1, 1, "b", False, None, True, {"proc": "x286", "maxmem": "640k"}, False)
+        == (1, 1, 1, "b", False, None, True, {"proc": "x286", "maxmem": "640k"}, True)
     )
 
 

--- a/test/tests_for_utils/job_requirements_resolver_test.py
+++ b/test/tests_for_utils/job_requirements_resolver_test.py
@@ -660,7 +660,7 @@ def test_resolve_requirements_from_spec():
     """
     _resolve_requirements_from_spec([])
     _resolve_requirements_from_spec([{}])
-    _resolve_requirements_from_spec([{'client_groups': []}])
+    _resolve_requirements_from_spec([{"client_groups": []}])
 
 
 def _resolve_requirements_from_spec(catalog_return):
@@ -675,15 +675,14 @@ def _resolve_requirements_from_spec(catalog_return):
         8,
         700,
         32,
-        'cg2',
+        "cg2",
         client_group_regex=False,
         debug_mode=True,
     )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "mod",
-        "function_name": "meth"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "mod", "function_name": "meth"}
+    )
 
 
 def test_resolve_requirements_from_spec_with_override():
@@ -691,38 +690,42 @@ def test_resolve_requirements_from_spec_with_override():
     Test that an override ignores client group information from all other sources.
     """
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{'client_groups': ["cg2"]}]
+    catalog.list_client_group_configs.return_value = [{"client_groups": ["cg2"]}]
 
     spec = _get_simple_deploy_spec_file_obj()
 
     jrr = JobRequirementsResolver(catalog, spec, "    cg1    ")
 
     assert jrr.resolve_requirements(
-        " module2. some_meth  ", client_group="cg2") == JobRequirements(
-            4,
-            2000,
-            100,
-            'cg1',
+        " module2. some_meth  ", client_group="cg2"
+    ) == JobRequirements(
+        4,
+        2000,
+        100,
+        "cg1",
     )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "module2",
-        "function_name": "some_meth"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "module2", "function_name": "some_meth"}
+    )
 
 
 def test_resolve_requirements_from_catalog_full_CSV():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{"client_groups": [
-        "cg1",
-        "request_cpus=  78",
-        "   request_memory   = 500MB",
-        "request_disk = 700GB",
-        "client_group_regex = False",
-        "debug_mode = true",
-        "foo=bar",
-        "baz=bat",
-    ]}]
+    catalog.list_client_group_configs.return_value = [
+        {
+            "client_groups": [
+                "cg1",
+                "request_cpus=  78",
+                "   request_memory   = 500MB",
+                "request_disk = 700GB",
+                "client_group_regex = False",
+                "debug_mode = true",
+                "foo=bar",
+                "baz=bat",
+            ]
+        }
+    ]
 
     spec = _get_simple_deploy_spec_file_obj()
 
@@ -732,7 +735,7 @@ def test_resolve_requirements_from_catalog_full_CSV():
         78,
         500,
         700,
-        'cg1',
+        "cg1",
         False,
         None,
         False,
@@ -740,20 +743,23 @@ def test_resolve_requirements_from_catalog_full_CSV():
         True,
     )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "module2",
-        "function_name": "some_meth"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "module2", "function_name": "some_meth"}
+    )
 
 
 def test_resolve_requirements_from_catalog_partial_JSON():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{"client_groups": [
-        '{"client_group": "  cg1  "',
-        '"    request_memory    ":  "  300M   "',
-        '"exactlythesameshape": "asathingy"',
-        '"request_disk": 100000}',
-    ]}]
+    catalog.list_client_group_configs.return_value = [
+        {
+            "client_groups": [
+                '{"client_group": "  cg1  "',
+                '"    request_memory    ":  "  300M   "',
+                '"exactlythesameshape": "asathingy"',
+                '"request_disk": 100000}',
+            ]
+        }
+    ]
 
     spec = _get_simple_deploy_spec_file_obj()
 
@@ -763,14 +769,13 @@ def test_resolve_requirements_from_catalog_partial_JSON():
         4,
         300,
         100000,
-        'cg1',
-        scheduler_requirements={"exactlythesameshape": "asathingy"}
+        "cg1",
+        scheduler_requirements={"exactlythesameshape": "asathingy"},
     )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "module2",
-        "function_name": "some_meth"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "module2", "function_name": "some_meth"}
+    )
 
 
 def test_resolve_requirements_from_user_full():
@@ -780,16 +785,20 @@ def test_resolve_requirements_from_user_full():
 
 def _resolve_requirements_from_user_full(bool_val):
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{"client_groups": [
-        "cg2",
-        "request_cpus=  78",
-        "   request_memory   = 500MB",
-        "request_disk = 700GB",
-        "client_group_regex = False",
-        "debug_mode = true",
-        "foo=bar",
-        "baz=bat",
-    ]}]
+    catalog.list_client_group_configs.return_value = [
+        {
+            "client_groups": [
+                "cg2",
+                "request_cpus=  78",
+                "   request_memory   = 500MB",
+                "request_disk = 700GB",
+                "client_group_regex = False",
+                "debug_mode = true",
+                "foo=bar",
+                "baz=bat",
+            ]
+        }
+    ]
 
     spec = _get_simple_deploy_spec_file_obj()
 
@@ -804,26 +813,30 @@ def _resolve_requirements_from_user_full(bool_val):
         bool_val,
         "some_poor_sucker",
         bool_val,
-        {"foo": "Some of you may die", "bar": "but that is a sacrifice I am willing to make"},
+        {
+            "foo": "Some of you may die",
+            "bar": "but that is a sacrifice I am willing to make",
+        },
         bool_val,
     ) == JobRequirements(
         42,
         789,
         1,
-        'cg1',
+        "cg1",
         bool_val,
         "some_poor_sucker",
         bool_val,
-        {"foo": "Some of you may die",
-         "bar": "but that is a sacrifice I am willing to make",
-         "baz": "bat"},
+        {
+            "foo": "Some of you may die",
+            "bar": "but that is a sacrifice I am willing to make",
+            "baz": "bat",
+        },
         bool_val,
     )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "module2",
-        "function_name": "some_meth"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "module2", "function_name": "some_meth"}
+    )
 
 
 def test_resolve_requirements_from_user_partial():
@@ -833,15 +846,19 @@ def test_resolve_requirements_from_user_partial():
     Also tests that special keys are removed from the scheduler requirements.
     """
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{"client_groups": [
-        "cg2",
-        "request_cpus=  78",
-        "request_disk = 700",
-        "client_group_regex = False",
-        "debug_mode = true",
-        "foo=bar",
-        "baz=bat",
-    ]}]
+    catalog.list_client_group_configs.return_value = [
+        {
+            "client_groups": [
+                "cg2",
+                "request_cpus=  78",
+                "request_disk = 700",
+                "client_group_regex = False",
+                "debug_mode = true",
+                "foo=bar",
+                "baz=bat",
+            ]
+        }
+    ]
 
     spec = _get_simple_deploy_spec_file_obj()
 
@@ -862,122 +879,193 @@ def test_resolve_requirements_from_user_partial():
             "bill_to_user": "foo",
             "ignore_concurrency_limits": "true",
             "whee": "whoo",
-        }
+        },
     ) == JobRequirements(
         42,
         2000,
         700,
-        'cg1',
+        "cg1",
         client_group_regex=True,
         scheduler_requirements={"foo": "bar", "baz": "bat", "whee": "whoo"},
         debug_mode=True,
     )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "module2",
-        "function_name": "some_meth"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "module2", "function_name": "some_meth"}
+    )
 
 
 def test_resolve_requirements_fail_illegal_inputs():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
     jrr = JobRequirementsResolver(catalog, _get_simple_deploy_spec_file_obj())
 
-    _resolve_requirements_fail(jrr, None, {}, IncorrectParamsException(
-        "Unrecognized method: 'None'. Please input module_name.function_name"))
-    _resolve_requirements_fail(jrr, "method", {}, IncorrectParamsException(
-        "Unrecognized method: 'method'. Please input module_name.function_name"))
-    _resolve_requirements_fail(jrr, "mod1.mod2.method", {}, IncorrectParamsException(
-        "Unrecognized method: 'mod1.mod2.method'. Please input module_name.function_name"))
-    _resolve_requirements_fail(jrr, "m.m", {"cpus": 0}, IncorrectParamsException(
-        "CPU count must be at least 1"))
-    _resolve_requirements_fail(jrr, "m.m", {"memory_MB": 0}, IncorrectParamsException(
-        "memory in MB must be at least 1"))
-    _resolve_requirements_fail(jrr, "m.m", {"disk_GB": 0}, IncorrectParamsException(
-        "disk space in GB must be at least 1"))
-    _resolve_requirements_fail(jrr, "m.m", {"client_group": "   \t   "}, IncorrectParamsException(
-        "Missing input parameter: client_group"))
-    _resolve_requirements_fail(jrr, "m.m", {"bill_to_user": "\b"}, IncorrectParamsException(
-        "bill_to_user contains control characters"))
     _resolve_requirements_fail(
-        jrr, "m.m", {"scheduler_requirements": {"a": None}}, IncorrectParamsException(
-            "Missing input parameter: value for key 'a' in scheduler requirements structure"))
+        jrr,
+        None,
+        {},
+        IncorrectParamsException(
+            "Unrecognized method: 'None'. Please input module_name.function_name"
+        ),
+    )
+    _resolve_requirements_fail(
+        jrr,
+        "method",
+        {},
+        IncorrectParamsException(
+            "Unrecognized method: 'method'. Please input module_name.function_name"
+        ),
+    )
+    _resolve_requirements_fail(
+        jrr,
+        "mod1.mod2.method",
+        {},
+        IncorrectParamsException(
+            "Unrecognized method: 'mod1.mod2.method'. Please input module_name.function_name"
+        ),
+    )
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {"cpus": 0},
+        IncorrectParamsException("CPU count must be at least 1"),
+    )
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {"memory_MB": 0},
+        IncorrectParamsException("memory in MB must be at least 1"),
+    )
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {"disk_GB": 0},
+        IncorrectParamsException("disk space in GB must be at least 1"),
+    )
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {"client_group": "   \t   "},
+        IncorrectParamsException("Missing input parameter: client_group"),
+    )
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {"bill_to_user": "\b"},
+        IncorrectParamsException("bill_to_user contains control characters"),
+    )
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {"scheduler_requirements": {"a": None}},
+        IncorrectParamsException(
+            "Missing input parameter: value for key 'a' in scheduler requirements structure"
+        ),
+    )
 
 
 def test_resolve_requirements_fail_catalog_multiple_entries():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{'client_groups': ["cg2"]}, {}]
+    catalog.list_client_group_configs.return_value = [{"client_groups": ["cg2"]}, {}]
 
     jrr = JobRequirementsResolver(catalog, _get_simple_deploy_spec_file_obj())
-    _resolve_requirements_fail(jrr, "m.m", {}, ValueError(
-        "Unexpected result from the Catalog service: more than one client group "
-        + "configuration found for method m.m"))
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {},
+        ValueError(
+            "Unexpected result from the Catalog service: more than one client group "
+            + "configuration found for method m.m"
+        ),
+    )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "m",
-        "function_name": "m"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "m", "function_name": "m"}
+    )
 
 
 def test_resolve_requirements_fail_catalog_bad_JSON():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{'client_groups': [
-        '{"foo": "bar", "baz":}']}]
+    catalog.list_client_group_configs.return_value = [
+        {"client_groups": ['{"foo": "bar", "baz":}']}
+    ]
 
     jrr = JobRequirementsResolver(catalog, _get_simple_deploy_spec_file_obj())
-    _resolve_requirements_fail(jrr, "m.m", {}, ValueError(
-        "Unable to parse JSON client group entry from catalog for method m.m"))
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {},
+        ValueError(
+            "Unable to parse JSON client group entry from catalog for method m.m"
+        ),
+    )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "m",
-        "function_name": "m"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "m", "function_name": "m"}
+    )
 
 
 def test_resolve_requirements_fail_catalog_bad_CSV():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{'client_groups': [
-        "cg", "foo is bar"]}]
+    catalog.list_client_group_configs.return_value = [
+        {"client_groups": ["cg", "foo is bar"]}
+    ]
 
     jrr = JobRequirementsResolver(catalog, _get_simple_deploy_spec_file_obj())
-    _resolve_requirements_fail(jrr, "m.m", {}, ValueError(
-        "Malformed requirement. Format is <key>=<value>. "
-        + "Item is 'foo is bar' for catalog method m.m"))
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {},
+        ValueError(
+            "Malformed requirement. Format is <key>=<value>. "
+            + "Item is 'foo is bar' for catalog method m.m"
+        ),
+    )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "m",
-        "function_name": "m"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "m", "function_name": "m"}
+    )
 
 
 def test_resolve_requirements_fail_catalog_normalize():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{'client_groups': [
-        "cg", "request_memory=72TB"]}]
+    catalog.list_client_group_configs.return_value = [
+        {"client_groups": ["cg", "request_memory=72TB"]}
+    ]
 
     jrr = JobRequirementsResolver(catalog, _get_simple_deploy_spec_file_obj())
-    _resolve_requirements_fail(jrr, " mod  . meth ", {}, IncorrectParamsException(
-        "Found illegal memory request '72TB' in job requirements from catalog method mod.meth"))
+    _resolve_requirements_fail(
+        jrr,
+        " mod  . meth ",
+        {},
+        IncorrectParamsException(
+            "Found illegal memory request '72TB' in job requirements from catalog method mod.meth"
+        ),
+    )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "mod",
-        "function_name": "meth"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "mod", "function_name": "meth"}
+    )
 
 
 def test_resolve_requirements_fail_catalog_clientgroup():
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
-    catalog.list_client_group_configs.return_value = [{'client_groups': [
-        "cg", "request_memory=72"]}]
+    catalog.list_client_group_configs.return_value = [
+        {"client_groups": ["cg", "request_memory=72"]}
+    ]
 
     jrr = JobRequirementsResolver(catalog, _get_simple_deploy_spec_file_obj())
-    _resolve_requirements_fail(jrr, " mod  . meth ", {}, IncorrectParamsException(
-        "Catalog specified illegal client group 'cg' for method mod.meth"))
+    _resolve_requirements_fail(
+        jrr,
+        " mod  . meth ",
+        {},
+        IncorrectParamsException(
+            "Catalog specified illegal client group 'cg' for method mod.meth"
+        ),
+    )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "mod",
-        "function_name": "meth"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "mod", "function_name": "meth"}
+    )
 
 
 def test_resolve_requirements_fail_input_clientgroup():
@@ -985,13 +1073,16 @@ def test_resolve_requirements_fail_input_clientgroup():
     catalog.list_client_group_configs.return_value = []
 
     jrr = JobRequirementsResolver(catalog, _get_simple_deploy_spec_file_obj())
-    _resolve_requirements_fail(jrr, "m.m", {"client_group": "cb4"}, IncorrectParamsException(
-        "No such clientgroup: cb4"))
+    _resolve_requirements_fail(
+        jrr,
+        "m.m",
+        {"client_group": "cb4"},
+        IncorrectParamsException("No such clientgroup: cb4"),
+    )
 
-    catalog.list_client_group_configs.assert_called_once_with({
-        "module_name": "m",
-        "function_name": "m"
-    })
+    catalog.list_client_group_configs.assert_called_once_with(
+        {"module_name": "m", "function_name": "m"}
+    )
 
 
 def _resolve_requirements_fail(jrr, method, kwargs, expected):


### PR DESCRIPTION
# Description of PR purpose/changes

Finally adds the job requirements resolver, which, given job requirements requests from the calling method (e.g. via the service API), the catalog client groups entry, and the default client group entries in the EE2 deploy.cfg file, figures out the requirements to use.

Integrates the following classes and methods into a single module:

[CatalogUtils, entire file is superceded](https://github.com/kbase/execution_engine2/blob/4984ef0c8c60940663b0332508d2c834b4a3e8a2/lib/execution_engine2/utils/CatalogUtils.py)
[Condor.extract_resources](https://github.com/kbase/execution_engine2/blob/4984ef0c8c60940663b0332508d2c834b4a3e8a2/lib/execution_engine2/utils/Condor.py#L126-L160)
[Condor.extract_requirements](https://github.com/kbase/execution_engine2/blob/4984ef0c8c60940663b0332508d2c834b4a3e8a2/lib/execution_engine2/utils/Condor.py#L126-L160)
[Condor.modify_with_concierge](https://github.com/kbase/execution_engine2/blob/4984ef0c8c60940663b0332508d2c834b4a3e8a2/lib/execution_engine2/utils/Condor.py#L249-L270)
[A good chunk of EE2RunJob._prepare_to_run](https://github.com/kbase/execution_engine2/blob/4984ef0c8c60940663b0332508d2c834b4a3e8a2/lib/execution_engine2/sdk/EE2Runjob.py#L189-L220)

All the negotiation regarding which requirements source to use will be hidden from the rest of the code once the new resolver is integrated in an upcoming PR.

Also, in JobRequirements.check_parameters, don't force a bool if the user doesn't specify one. Leave that to the constructor.

This is a bit bigger than I expected it to be, sorry. It's 99% greenfield though, so hopefully that makes the review a bit easier.

# Jira Ticket / Github Issue #
- [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [X] [Version has been bumped](https://semver.org/) for each release
- [X] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
