### PR TITLE
DATAUP-389 - Make the user client group override the override

### DIFF
--- a/lib/execution_engine2/utils/job_requirements_resolver.py
+++ b/lib/execution_engine2/utils/job_requirements_resolver.py
@@ -447,8 +447,8 @@ class JobRequirementsResolver:
         cg = next(
             i
             for i in [
-                self._override_client_group,
                 user_cg,
+                self._override_client_group,
                 catalog_cg,
                 self._default_client_group,
             ]


### PR DESCRIPTION
# Description of PR purpose/changes

After reviewing the code again, it's clear that any user (who is presumed
to be a catalog admin) provided client group should override every other
source, including the `OVERRIDE_CLIENT_GROUP` environmental variable.

# Jira Ticket / Github Issue #
- [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k+ warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
