### PR TITLE
DATAUP-389 - integrate the job requirements resolver pt 1

### DIFF
--- a/lib/execution_engine2/execution_engine2Impl.py
+++ b/lib/execution_engine2/execution_engine2Impl.py
@@ -63,7 +63,9 @@ class execution_engine2:
         self.gen_cfg = GenerateFromConfig(config)
         # move these into GFC? Since they're only generated once it doesn't seem necessary
         configpath = os.environ["KB_DEPLOYMENT_CONFIG"]
-        self.clients = get_client_set(config, configpath)
+        override = os.environ.get("OVERRIDE_CLIENT_GROUP")
+        with open(configpath) as cf:
+            self.clients = get_client_set(config, configpath, cf, override)
         #END_CONSTRUCTOR
         pass
 

--- a/lib/execution_engine2/utils/clients.py
+++ b/lib/execution_engine2/utils/clients.py
@@ -113,7 +113,9 @@ class ClientSet:
         self.auth_admin = _not_falsy(auth_admin, "auth_admin")
         self.condor = _not_falsy(condor, "condor")
         self.catalog = _not_falsy(catalog, "catalog")
-        self.requirements_resolver = _not_falsy(requirements_resolver, "requirements_resolver")
+        self.requirements_resolver = _not_falsy(
+            requirements_resolver, "requirements_resolver"
+        )
         self.catalog_utils = _not_falsy(catalog_utils, "catalog_utils")
         self.kafka_client = _not_falsy(kafka_client, "kafka_client")
         self.mongo_util = _not_falsy(mongo_util, "mongo_util")
@@ -126,7 +128,10 @@ class ClientSet:
 
 def get_clients(
     # TODO JRR remove cfg_path when Condor no longer needs it
-    cfg: Dict[str, str], cfg_path, cfg_file: Iterable[str], override_client_group: str = None
+    cfg: Dict[str, str],
+    cfg_path,
+    cfg_file: Iterable[str],
+    override_client_group: str = None,
 ) -> (
     KBaseAuth,
     AdminAuthUtil,
@@ -162,7 +167,9 @@ def get_clients(
     # token is needed for running log_exec_stats in EE2Status
     catalog = Catalog(cfg["catalog-url"], token=cfg["catalog-token"])
     # make a separate, hidden catalog instance
-    jrr = JobRequirementsResolver(Catalog(cfg["catalog-url"]), cfg_file, override_client_group)
+    jrr = JobRequirementsResolver(
+        Catalog(cfg["catalog-url"]), cfg_file, override_client_group
+    )
     catalog_utils = CatalogUtils(cfg["catalog-url"], cfg["catalog-token"])
     auth_url = cfg["auth-url"]
     auth = KBaseAuth(auth_url=auth_url + "/api/legacy/KBase/Sessions/Login")
@@ -195,11 +202,12 @@ def get_clients(
 
 
 def get_client_set(
-        cfg: Dict[str, str],
-        # TODO JRR remove cfg_path when Condor no longer needs it
-        cfg_path: str,
-        cfg_file: Iterable[str],
-        override_client_group: str = None) -> ClientSet:
+    cfg: Dict[str, str],
+    # TODO JRR remove cfg_path when Condor no longer needs it
+    cfg_path: str,
+    cfg_file: Iterable[str],
+    override_client_group: str = None,
+) -> ClientSet:
     """
     A helper method to create a ClientSet from a config dict rather than constructing and passing
     in clients individually.

--- a/lib/execution_engine2/utils/clients.py
+++ b/lib/execution_engine2/utils/clients.py
@@ -3,7 +3,6 @@
 # Note on testing - this class is not generally unit-testable, and is only tested fully in
 # integration tests.
 
-import os
 from typing import Dict, Iterable
 
 from execution_engine2.authorization.roles import AdminAuthUtil

--- a/test/tests_for_auth/ee2_admin_mode_test.py
+++ b/test/tests_for_auth/ee2_admin_mode_test.py
@@ -95,7 +95,8 @@ class EE2TestAdminMode(unittest.TestCase):
         if not user_clients:
             user_clients = get_user_client_set(self.cfg, self.user_id, self.token)
         if not clients:
-            clients = get_client_set(self.cfg, self.config_file)
+            with open(self.config_file) as cf:
+                clients = get_client_set(self.cfg, self.config_file, cf)
         runner = SDKMethodRunner(user_clients, clients)  # type : SDKMethodRunner
         runner.get_jobs_status()
         runner.get_runjob()

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_EE2Logs_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_EE2Logs_test.py
@@ -35,10 +35,11 @@ class ee2_SDKMethodRunner_test_ee2_logs(unittest.TestCase):
         cls.ws_id = 9999
         cls.token = "token"
 
-        cls.method_runner = SDKMethodRunner(
-            get_user_client_set(cls.cfg, cls.user_id, cls.token),
-            get_client_set(cls.cfg, deploy),
-        )
+        with open(deploy) as cf:
+            cls.method_runner = SDKMethodRunner(
+                get_user_client_set(cls.cfg, cls.user_id, cls.token),
+                get_client_set(cls.cfg, deploy, cf),
+            )
         cls.mongo_util = MongoUtil(cls.cfg)
         cls.mongo_helper = MongoTestHelper(cls.cfg)
 

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -72,10 +72,11 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         cls.ws_id = 9999
         cls.token = "token"
 
-        cls.method_runner = SDKMethodRunner(
-            get_user_client_set(cls.cfg, cls.user_id, cls.token),
-            get_client_set(cls.cfg, cls.config_file),
-        )
+        with open(cls.config_file) as cf:
+            cls.method_runner = SDKMethodRunner(
+                get_user_client_set(cls.cfg, cls.user_id, cls.token),
+                get_client_set(cls.cfg, cls.config_file, cf),
+            )
         cls.mongo_util = MongoUtil(cls.cfg)
         cls.mongo_helper = MongoTestHelper(cls.cfg)
 
@@ -724,10 +725,11 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
             self.assertEqual(job_states[job_id]["status"], "created")
 
             # now test with a different user
-            other_method_runner = SDKMethodRunner(
-                get_user_client_set(self.cfg, "some_other_user", "other_token"),
-                get_client_set(self.cfg, self.config_file),
-            )
+            with open(self.config_file) as cf:
+                other_method_runner = SDKMethodRunner(
+                    get_user_client_set(self.cfg, "some_other_user", "other_token"),
+                    get_client_set(self.cfg, self.config_file, cf),
+                )
             job_states = other_method_runner.get_jobs_status().check_workspace_jobs(
                 self.ws_id
             )

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
@@ -53,10 +53,11 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         cls.ws_id = 9999
         cls.token = "token"
 
-        cls.method_runner = SDKMethodRunner(
-            get_user_client_set(cls.cfg, cls.user_id, cls.token),
-            get_client_set(cls.cfg, config_file),
-        )
+        with open(config_file) as cf:
+            cls.method_runner = SDKMethodRunner(
+                get_user_client_set(cls.cfg, cls.user_id, cls.token),
+                get_client_set(cls.cfg, config_file, cf),
+            )
 
         cls.mongo_util = MongoUtil(cls.cfg)
         cls.mongo_helper = MongoTestHelper(cls.cfg)

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Status_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Status_test.py
@@ -45,10 +45,11 @@ class ee2_SDKMethodRunner_test_status(unittest.TestCase):
         cls.ws_id = 9999
         cls.token = "token"
 
-        cls.method_runner = SDKMethodRunner(
-            get_user_client_set(cls.cfg, cls.user_id, cls.token),
-            get_client_set(cls.cfg, config_file),
-        )
+        with open(config_file) as cf:
+            cls.method_runner = SDKMethodRunner(
+                get_user_client_set(cls.cfg, cls.user_id, cls.token),
+                get_client_set(cls.cfg, config_file, cf),
+            )
         cls.cr = CondorResources(
             request_cpus="1",
             request_disk="1GB",

--- a/test/tests_for_sdkmr/ee2_load_test.py
+++ b/test/tests_for_sdkmr/ee2_load_test.py
@@ -55,10 +55,11 @@ class ee2_server_load_test(unittest.TestCase):
 
     @classmethod
     def _getRunner(cls) -> SDKMethodRunner:
-        runner = SDKMethodRunner(
-            get_user_client_set(cls.cfg, cls.user_id, cls.token),
-            get_client_set(cls.cfg, cls.deploy),
-        )
+        with open(cls.deploy) as cf:
+            runner = SDKMethodRunner(
+                get_user_client_set(cls.cfg, cls.user_id, cls.token),
+                get_client_set(cls.cfg, cls.deploy, cf),
+            )
         # Initialize these clients from None
         status = runner.get_jobs_status()  # type: JobsStatus
         status._send_exec_stats_to_catalog = MagicMock(return_value=True)

--- a/test/tests_for_utils/clients_test.py
+++ b/test/tests_for_utils/clients_test.py
@@ -5,7 +5,11 @@ from pytest import raises
 from unittest.mock import create_autospec
 
 from execution_engine2.authorization.workspaceauth import WorkspaceAuth
-from execution_engine2.utils.clients import UserClientSet, get_user_client_set, ClientSet
+from execution_engine2.utils.clients import (
+    UserClientSet,
+    get_user_client_set,
+    ClientSet,
+)
 from utils_shared.test_utils import assert_exception_correct
 from utils_shared.mock_utils import get_client_mocks, ALL_CLIENTS
 from installed_clients.WorkspaceClient import Workspace
@@ -128,6 +132,15 @@ def _client_set_init_fail(
     expected: Exception,
 ):
     with raises(Exception) as got:
-        ClientSet(auth, auth_admin, condor, catalog, requirements_resolver, catalog_utils,
-                  kafka_client, mongo_util, slack_client)
+        ClientSet(
+            auth,
+            auth_admin,
+            condor,
+            catalog,
+            requirements_resolver,
+            catalog_utils,
+            kafka_client,
+            mongo_util,
+            slack_client,
+        )
     assert_exception_correct(got.value, expected)

--- a/test/tests_for_utils/clients_test.py
+++ b/test/tests_for_utils/clients_test.py
@@ -5,9 +5,21 @@ from pytest import raises
 from unittest.mock import create_autospec
 
 from execution_engine2.authorization.workspaceauth import WorkspaceAuth
-from execution_engine2.utils.clients import UserClientSet, get_user_client_set
+from execution_engine2.utils.clients import UserClientSet, get_user_client_set, ClientSet
 from utils_shared.test_utils import assert_exception_correct
+from utils_shared.mock_utils import get_client_mocks, ALL_CLIENTS
 from installed_clients.WorkspaceClient import Workspace
+
+from execution_engine2.authorization.roles import AdminAuthUtil
+from execution_engine2.db.MongoUtil import MongoUtil
+from execution_engine2.utils.CatalogUtils import CatalogUtils
+from execution_engine2.utils.Condor import Condor
+from execution_engine2.utils.job_requirements_resolver import JobRequirementsResolver
+from execution_engine2.utils.KafkaUtils import KafkaClient
+from execution_engine2.utils.SlackUtils import SlackClient
+
+from installed_clients.authclient import KBaseAuth
+from installed_clients.CatalogClient import Catalog
 
 
 def test_get_user_client_set_fail():
@@ -68,3 +80,54 @@ def user_client_set_init_fail(user, token, ws_client, ws_auth, expected):
     with raises(Exception) as e:
         UserClientSet(user, token, ws_client, ws_auth)
     assert_exception_correct(e.value, expected)
+
+
+def test_client_set_init_fail():
+    mocks = get_client_mocks(None, None, *ALL_CLIENTS)
+    a = mocks[KBaseAuth]
+    aa = mocks[AdminAuthUtil]
+    c = mocks[Condor]
+    ca = mocks[Catalog]
+    j = mocks[JobRequirementsResolver]
+    cu = mocks[CatalogUtils]
+    k = mocks[KafkaClient]
+    m = mocks[MongoUtil]
+    s = mocks[SlackClient]
+    n = None
+
+    e = ValueError("auth cannot be a value that evaluates to false")
+    _client_set_init_fail(n, aa, c, ca, j, cu, k, m, s, e)
+    e = ValueError("auth_admin cannot be a value that evaluates to false")
+    _client_set_init_fail(a, n, c, ca, j, cu, k, m, s, e)
+    e = ValueError("condor cannot be a value that evaluates to false")
+    _client_set_init_fail(a, aa, n, ca, j, cu, k, m, s, e)
+    e = ValueError("catalog cannot be a value that evaluates to false")
+    _client_set_init_fail(a, aa, c, n, j, cu, k, m, s, e)
+    e = ValueError("requirements_resolver cannot be a value that evaluates to false")
+    _client_set_init_fail(a, aa, c, ca, n, cu, k, m, s, e)
+    e = ValueError("catalog_utils cannot be a value that evaluates to false")
+    _client_set_init_fail(a, aa, c, ca, j, n, k, m, s, e)
+    e = ValueError("kafka_client cannot be a value that evaluates to false")
+    _client_set_init_fail(a, aa, c, ca, j, cu, n, m, s, e)
+    e = ValueError("mongo_util cannot be a value that evaluates to false")
+    _client_set_init_fail(a, aa, c, ca, j, cu, k, n, s, e)
+    e = ValueError("slack_client cannot be a value that evaluates to false")
+    _client_set_init_fail(a, aa, c, ca, j, cu, k, m, n, e)
+
+
+def _client_set_init_fail(
+    auth: KBaseAuth,
+    auth_admin: AdminAuthUtil,
+    condor: Condor,
+    catalog: Catalog,
+    requirements_resolver: JobRequirementsResolver,
+    catalog_utils: CatalogUtils,
+    kafka_client: KafkaClient,
+    mongo_util: MongoUtil,
+    slack_client: SlackClient,
+    expected: Exception,
+):
+    with raises(Exception) as got:
+        ClientSet(auth, auth_admin, condor, catalog, requirements_resolver, catalog_utils,
+                  kafka_client, mongo_util, slack_client)
+    assert_exception_correct(got.value, expected)

--- a/test/utils_shared/mock_utils.py
+++ b/test/utils_shared/mock_utils.py
@@ -2,15 +2,23 @@ from unittest.mock import create_autospec
 
 from execution_engine2.db.MongoUtil import MongoUtil
 from execution_engine2.utils.CatalogUtils import CatalogUtils
+from execution_engine2.utils.job_requirements_resolver import JobRequirementsResolver
 from execution_engine2.utils.KafkaUtils import KafkaClient
 from execution_engine2.utils.SlackUtils import SlackClient
 
 from installed_clients.authclient import KBaseAuth
+from installed_clients.CatalogClient import Catalog
 
 from execution_engine2.authorization.roles import AdminAuthUtil
 from execution_engine2.utils.Condor import Condor
 from execution_engine2.sdk.EE2Constants import ADMIN_READ_ROLE, ADMIN_WRITE_ROLE
 from execution_engine2.utils.clients import ClientSet
+
+
+def _build_job_reqs(config, cfgfile):
+    with open(cfgfile) as cf:
+        return JobRequirementsResolver(Catalog(config["catalog-url"]), cf)
+
 
 _CLASS_IMPLEMENTATION_BUILDERS = {
     KBaseAuth: lambda config, cfgfile: KBaseAuth(
@@ -20,6 +28,8 @@ _CLASS_IMPLEMENTATION_BUILDERS = {
         config["auth-url"], [ADMIN_READ_ROLE, ADMIN_WRITE_ROLE]
     ),
     Condor: lambda config, cfgfile: Condor(cfgfile),
+    Catalog: lambda config, cfgfile: Catalog(config["catalog-url"]),
+    JobRequirementsResolver: _build_job_reqs,
     CatalogUtils: lambda config, cfgfile: CatalogUtils(
         config["catalog-url"], config["catalog-token"]
     ),
@@ -55,6 +65,8 @@ def get_client_mocks(config, config_path, *to_be_mocked):
         ret[KBaseAuth],
         ret[AdminAuthUtil],
         ret[Condor],
+        ret[Catalog],
+        ret[JobRequirementsResolver],
         ret[CatalogUtils],
         ret[KafkaClient],
         ret[MongoUtil],


### PR DESCRIPTION
# Description of PR purpose/changes

Adds catalog client and job reqs resolver to the client set.
Nothing does anything with them yet - will be tested more thoroughly when that happens.

Adds a separate field for the catalog client, as the job reqs resolver will make CatalogUtils redundant.

# Jira Ticket / Github Issue #
- [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k+ warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [X] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
