### PR TITLE
DATAUP-389 - add getters for new clients & missing getters

### DIFF
--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -117,9 +117,8 @@ class EE2RunJob:
 
         self.logger.debug(f"Getting commit for {module_name} {service_ver}")
 
-        module_version = (
-            self.sdkmr.get_catalog()
-            .get_module_version({"module_name": module_name, "version": service_ver})
+        module_version = self.sdkmr.get_catalog().get_module_version(
+            {"module_name": module_name, "version": service_ver}
         )
 
         git_commit_hash = module_version.get("git_commit_hash")

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -142,7 +142,7 @@ class EE2RunJob:
 
     def _check_workspace_permissions(self, wsid):
         if wsid:
-            if not self.sdkmr.workspace_auth.can_write(wsid):
+            if not self.sdkmr.get_workspace_auth().can_write(wsid):
                 self.logger.debug(
                     f"User {self.sdkmr.user_id} doesn't have permission to run jobs in workspace {wsid}."
                 )
@@ -151,7 +151,7 @@ class EE2RunJob:
                 )
 
     def _check_workspace_permissions_list(self, wsids):
-        perms = self.sdkmr.workspace_auth.can_write_list(wsids)
+        perms = self.sdkmr.get_workspace_auth().can_write_list(wsids)
         bad_ws = [key for key in perms.keys() if perms[key] is False]
         if bad_ws:
             self.logger.debug(

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -118,8 +118,7 @@ class EE2RunJob:
         self.logger.debug(f"Getting commit for {module_name} {service_ver}")
 
         module_version = (
-            self.sdkmr.get_catalog_utils()
-            .get_catalog()
+            self.sdkmr.get_catalog()
             .get_module_version({"module_name": module_name, "version": service_ver})
         )
 

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -549,9 +549,7 @@ class JobsStatus:
         log_exec_stats_params["is_error"] = int(job.status == Status.error.value)
         log_exec_stats_params["job_id"] = job_id
 
-        self.sdkmr.get_catalog_utils().get_catalog().log_exec_stats(
-            log_exec_stats_params
-        )
+        self.sdkmr.get_catalog().log_exec_stats(log_exec_stats_params)
 
     def abandon_children(self, parent_job_id, child_job_ids, as_admin=False) -> Dict:
         if not parent_job_id:

--- a/lib/execution_engine2/sdk/SDKMethodRunner.py
+++ b/lib/execution_engine2/sdk/SDKMethodRunner.py
@@ -28,6 +28,7 @@ from lib.execution_engine2.sdk import (
 from lib.execution_engine2.sdk.EE2Constants import KBASE_CONCIERGE_USERNAME
 from lib.execution_engine2.utils.CatalogUtils import CatalogUtils
 from lib.execution_engine2.utils.Condor import Condor
+from execution_engine2.authorization.workspaceauth import WorkspaceAuth
 from execution_engine2.utils.job_requirements_resolver import JobRequirementsResolver
 from execution_engine2.utils.clients import UserClientSet, ClientSet
 from lib.execution_engine2.utils.EE2Logger import get_logger as _get_logger
@@ -140,6 +141,12 @@ class SDKMethodRunner:
         Get the workspace client for this instance of SDKMR.
         """
         return self.workspace
+
+    def get_workspace_auth(self) -> WorkspaceAuth:
+        """
+        Get the workspace authorization client for this instance of SDKMR.
+        """
+        return self.workspace_auth
 
     def get_logger(self) -> Logger:
         """

--- a/lib/execution_engine2/sdk/SDKMethodRunner.py
+++ b/lib/execution_engine2/sdk/SDKMethodRunner.py
@@ -28,11 +28,12 @@ from lib.execution_engine2.sdk import (
 from lib.execution_engine2.sdk.EE2Constants import KBASE_CONCIERGE_USERNAME
 from lib.execution_engine2.utils.CatalogUtils import CatalogUtils
 from lib.execution_engine2.utils.Condor import Condor
+from execution_engine2.utils.clients import UserClientSet, ClientSet
 from lib.execution_engine2.utils.EE2Logger import get_logger as _get_logger
 from lib.execution_engine2.utils.KafkaUtils import KafkaClient
 from lib.execution_engine2.utils.SlackUtils import SlackClient
+from installed_clients.CatalogClient import Catalog
 from installed_clients.WorkspaceClient import Workspace
-from execution_engine2.utils.clients import UserClientSet, ClientSet
 
 
 class JobPermissions(Enum):
@@ -65,6 +66,7 @@ class SDKMethodRunner:
             raise ValueError("clients is required")
         self.mongo_util = clients.mongo_util
         self.condor = clients.condor
+        self.catalog = clients.catalog
         self.workspace = user_clients.workspace
         self.workspace_auth = user_clients.workspace_auth
         self.catalog_utils = clients.catalog_utils
@@ -144,6 +146,12 @@ class SDKMethodRunner:
         # There's not really any way to meaningfully test this method without passing in the
         # logger, which seems... overkill?
         return self.logger
+
+    def get_catalog(self) -> Catalog:
+        """
+        Get the catalog client for this instance of SDKMR.
+        """
+        return self.catalog
 
     def get_catalog_utils(self) -> CatalogUtils:
         """

--- a/lib/execution_engine2/sdk/SDKMethodRunner.py
+++ b/lib/execution_engine2/sdk/SDKMethodRunner.py
@@ -28,6 +28,7 @@ from lib.execution_engine2.sdk import (
 from lib.execution_engine2.sdk.EE2Constants import KBASE_CONCIERGE_USERNAME
 from lib.execution_engine2.utils.CatalogUtils import CatalogUtils
 from lib.execution_engine2.utils.Condor import Condor
+from execution_engine2.utils.job_requirements_resolver import JobRequirementsResolver
 from execution_engine2.utils.clients import UserClientSet, ClientSet
 from lib.execution_engine2.utils.EE2Logger import get_logger as _get_logger
 from lib.execution_engine2.utils.KafkaUtils import KafkaClient
@@ -67,6 +68,7 @@ class SDKMethodRunner:
         self.mongo_util = clients.mongo_util
         self.condor = clients.condor
         self.catalog = clients.catalog
+        self.job_requirements_resolver = clients.requirements_resolver
         self.workspace = user_clients.workspace
         self.workspace_auth = user_clients.workspace_auth
         self.catalog_utils = clients.catalog_utils
@@ -152,6 +154,12 @@ class SDKMethodRunner:
         Get the catalog client for this instance of SDKMR.
         """
         return self.catalog
+
+    def get_job_requirements_resolver(self) -> JobRequirementsResolver:
+        """
+        Get the job requirements resolver for this instance of SDKMR.
+        """
+        return self.job_requirements_resolver
 
     def get_catalog_utils(self) -> CatalogUtils:
         """

--- a/test/tests_for_auth/ee2_admin_mode_test.py
+++ b/test/tests_for_auth/ee2_admin_mode_test.py
@@ -58,7 +58,7 @@ class EE2TestAdminMode(unittest.TestCase):
         :return:
         """
         self.catalog_patch = patch(
-            "lib.installed_clients.CatalogClient.Catalog.get_module_version"
+            "installed_clients.CatalogClient.Catalog.get_module_version"
         )
         self.catalog = self.catalog_patch.start()
         self.catalog.return_value = {"git_commit_hash": "moduleversiongoeshere"}
@@ -128,7 +128,8 @@ class EE2TestAdminMode(unittest.TestCase):
     def get_client_mocks(self, *to_be_mocked):
         return _get_client_mocks(self.cfg, self.config_file, *to_be_mocked)
 
-    @patch.object(Catalog, "get_module_version", return_value="module.version")
+    @patch.object(
+        Catalog, "get_module_version", return_value={"git_commit_hash": "moduleversiongoeshere"})
     def test_regular_user(self, catalog):
         # Regular User
         lowly_user = "Access Denied: You are not an administrator"
@@ -213,7 +214,8 @@ class EE2TestAdminMode(unittest.TestCase):
 
         # Start the job and get its status as an admin
 
-    @patch.object(Catalog, "get_module_version", return_value="module.version")
+    @patch.object(
+        Catalog, "get_module_version", return_value={"git_commit_hash": "moduleversiongoeshere"})
     @patch.object(WorkspaceAuth, "can_write", return_value=True)
     def test_admin_writer(self, workspace, catalog):
         # Admin User with WRITE

--- a/test/tests_for_auth/ee2_admin_mode_test.py
+++ b/test/tests_for_auth/ee2_admin_mode_test.py
@@ -129,7 +129,10 @@ class EE2TestAdminMode(unittest.TestCase):
         return _get_client_mocks(self.cfg, self.config_file, *to_be_mocked)
 
     @patch.object(
-        Catalog, "get_module_version", return_value={"git_commit_hash": "moduleversiongoeshere"})
+        Catalog,
+        "get_module_version",
+        return_value={"git_commit_hash": "moduleversiongoeshere"},
+    )
     def test_regular_user(self, catalog):
         # Regular User
         lowly_user = "Access Denied: You are not an administrator"
@@ -215,7 +218,10 @@ class EE2TestAdminMode(unittest.TestCase):
         # Start the job and get its status as an admin
 
     @patch.object(
-        Catalog, "get_module_version", return_value={"git_commit_hash": "moduleversiongoeshere"})
+        Catalog,
+        "get_module_version",
+        return_value={"git_commit_hash": "moduleversiongoeshere"},
+    )
     @patch.object(WorkspaceAuth, "can_write", return_value=True)
     def test_admin_writer(self, workspace, catalog):
         # Admin User with WRITE

--- a/test/tests_for_auth/ee2_admin_mode_test.py
+++ b/test/tests_for_auth/ee2_admin_mode_test.py
@@ -54,15 +54,9 @@ class EE2TestAdminMode(unittest.TestCase):
 
     def setUp(self) -> None:
         """
-        Patch out Catalog and Condor
+        Patch out Condor
         :return:
         """
-        self.catalog_patch = patch(
-            "installed_clients.CatalogClient.Catalog.get_module_version"
-        )
-        self.catalog = self.catalog_patch.start()
-        self.catalog.return_value = {"git_commit_hash": "moduleversiongoeshere"}
-
         si = SubmissionInfo(clusterid="123", submit={}, error=None)
         self.condor_patch = patch.object(
             target=Condor, attribute="run_job", return_value=si
@@ -86,7 +80,6 @@ class EE2TestAdminMode(unittest.TestCase):
         # self.good_job_id_user2 = setup_runner.run_job(params=job_params_1,as_admin=False)
 
     def tearDown(self) -> None:
-        self.catalog_patch.stop()
         self.condor_patch.stop()
         self.condor_patch2.start()
 

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -68,7 +68,7 @@ def test_run_as_admin():
     slack = create_autospec(SlackClient, spec_set=True, instance=True)
     ws = create_autospec(Workspace, spec_set=True, instance=True)
     # Set up basic getter calls
-    catutils.get_catalog.return_value = catalog
+    sdkmr.get_catalog.return_value = catalog
     sdkmr.get_catalog_utils.return_value = catutils
     sdkmr.get_condor.return_value = condor
     sdkmr.get_kafka_client.return_value = kafka

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -50,15 +50,13 @@ def test_finish_job_complete_minimal():
     logger = create_autospec(Logger, spec_set=True, instance=True)
     mongo = create_autospec(MongoUtil, spec_set=True, instance=True)
     kafka = create_autospec(KafkaClient, spec_set=True, instance=True)
-    catutil = create_autospec(CatalogUtils, spec_set=True, instance=True)
     catalog = create_autospec(Catalog, spec_set=True, instance=True)
     condor = create_autospec(Condor, spec_set=True, instance=True)
     sdkmr.get_mongo_util.return_value = mongo
     sdkmr.get_logger.return_value = logger
     sdkmr.get_kafka_client.return_value = kafka
     sdkmr.get_condor.return_value = condor
-    sdkmr.get_catalog_utils.return_value = catutil
-    catutil.get_catalog.return_value = catalog
+    sdkmr.get_catalog.return_value = catalog
 
     # set up return values for mocks. Ordered as per order of operations in code
     job1 = _finish_job_complete_minimal_get_test_job(

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -162,6 +162,7 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         sdkmr = SDKMethodRunner(user_clients, clients_and_mocks[ClientSet])
 
         assert sdkmr.get_workspace() is ws
+        assert sdkmr.get_workspace_auth() is wsa
         assert sdkmr.get_user_id() == "user"
         assert sdkmr.get_token() == "token"
         assert sdkmr.get_kafka_client() is clients_and_mocks[KafkaClient]

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -170,7 +170,10 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         assert sdkmr.get_catalog_utils() is clients_and_mocks[CatalogUtils]
         assert sdkmr.get_condor() is clients_and_mocks[Condor]
         assert sdkmr.get_catalog() is clients_and_mocks[Catalog]
-        assert sdkmr.get_job_requirements_resolver() is clients_and_mocks[JobRequirementsResolver]
+        assert (
+            sdkmr.get_job_requirements_resolver()
+            is clients_and_mocks[JobRequirementsResolver]
+        )
 
     def test_save_job(self):
         ws = Workspace("https://fake.com")

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -46,6 +46,7 @@ bootstrap()
 
 from lib.execution_engine2.sdk.EE2Runjob import EE2RunJob
 
+from installed_clients.CatalogClient import Catalog
 from installed_clients.WorkspaceClient import Workspace
 
 
@@ -167,6 +168,7 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         assert sdkmr.get_slack_client() is clients_and_mocks[SlackClient]
         assert sdkmr.get_catalog_utils() is clients_and_mocks[CatalogUtils]
         assert sdkmr.get_condor() is clients_and_mocks[Condor]
+        assert sdkmr.get_catalog() is clients_and_mocks[Catalog]
 
     def test_save_job(self):
         ws = Workspace("https://fake.com")

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -23,6 +23,7 @@ from execution_engine2.utils.CatalogUtils import CatalogUtils
 from execution_engine2.utils.Condor import Condor
 from execution_engine2.utils.KafkaUtils import KafkaClient
 from execution_engine2.utils.SlackUtils import SlackClient
+from execution_engine2.utils.job_requirements_resolver import JobRequirementsResolver
 from lib.execution_engine2.db.models.models import Job, Status, TerminatedCode
 from execution_engine2.exceptions import AuthError
 from lib.execution_engine2.exceptions import InvalidStatusTransitionException
@@ -169,6 +170,7 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         assert sdkmr.get_catalog_utils() is clients_and_mocks[CatalogUtils]
         assert sdkmr.get_condor() is clients_and_mocks[Condor]
         assert sdkmr.get_catalog() is clients_and_mocks[Catalog]
+        assert sdkmr.get_job_requirements_resolver() is clients_and_mocks[JobRequirementsResolver]
 
     def test_save_job(self):
         ws = Workspace("https://fake.com")

--- a/test/tests_for_sdkmr/ee2_load_test.py
+++ b/test/tests_for_sdkmr/ee2_load_test.py
@@ -243,9 +243,7 @@ class ee2_server_load_test(unittest.TestCase):
 
     @patch.object(Condor, "run_job", return_value=si)
     @patch.object(WorkspaceAuth, "can_write", return_value=True)
-    @patch(
-        "installed_clients.CatalogClient.Catalog.get_module_version", autospec=True
-    )
+    @patch("installed_clients.CatalogClient.Catalog.get_module_version", autospec=True)
     @patch("installed_clients.CatalogClient.Catalog.log_exec_stats", autospec=True)
     def test_run_job_stress(self, ccles, cc, workspace, condor):
         """

--- a/test/tests_for_sdkmr/ee2_load_test.py
+++ b/test/tests_for_sdkmr/ee2_load_test.py
@@ -244,9 +244,9 @@ class ee2_server_load_test(unittest.TestCase):
     @patch.object(Condor, "run_job", return_value=si)
     @patch.object(WorkspaceAuth, "can_write", return_value=True)
     @patch(
-        "lib.installed_clients.CatalogClient.Catalog.get_module_version", autospec=True
+        "installed_clients.CatalogClient.Catalog.get_module_version", autospec=True
     )
-    @patch("lib.installed_clients.CatalogClient.Catalog.log_exec_stats", autospec=True)
+    @patch("installed_clients.CatalogClient.Catalog.log_exec_stats", autospec=True)
     def test_run_job_stress(self, ccles, cc, workspace, condor):
         """
         testing running 3 different jobs in multiple theads.


### PR DESCRIPTION
# Description of PR purpose/changes

Adds several getters for clients that were added to the client set in the last PR, and for clients for which getters will be needed for the upcoming integration of the job requirements resolver code in order to mock said clients.

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [? My changes generate no new warnings - 3k+ warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
