### PR TITLE
DATAUP-389 - remove unused fields

### DIFF
--- a/lib/execution_engine2/sdk/SDKMethodRunner.py
+++ b/lib/execution_engine2/sdk/SDKMethodRunner.py
@@ -90,8 +90,6 @@ class SDKMethodRunner:
             expire=self.JOB_PERMISSION_CACHE_EXPIRE_TIME,
         )
 
-        self.is_admin = False
-        # self.roles = self.roles_cache.get_roles(user_id,token) or list()
         self._ee2_runjob = None
         self._ee2_status = None
         self._ee2_logs = None

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -263,8 +263,6 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         runner = self.getRunner()
         runner.workspace_auth = MagicMock()
         runner.auth.get_user = MagicMock(return_value=user_name)
-        runner.is_admin = True
-        runner._is_admin = MagicMock(return_value=True)
 
         runner.workspace_auth.can_read = MagicMock(return_value=True)
         runner.get_permissions_for_workspace = MagicMock(return_value=True)
@@ -946,7 +944,6 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
 
         runner.workspace_auth = MagicMock()
         runner.auth.get_user = MagicMock(return_value=user_name)
-        runner.is_admin = True
         runner.check_is_admin = MagicMock(return_value=True)
 
         runner.workspace_auth.can_read = MagicMock(return_value=True)
@@ -1060,7 +1057,6 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
             # runner.get_permissions_for_workspace = MagicMock(
             #     return_value=SDKMethodRunner.WorkspacePermissions.ADMINISTRATOR
             # )
-            runner.is_admin = MagicMock(return_value=True)
 
             print(
                 "Test case 1. Retrieving Jobs from last_week and tomorrow_max (yesterday and now jobs) "
@@ -1129,7 +1125,6 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
                 )
 
             print("Test case 2B. Same as above but with FAKE user (NO ADMIN) ")
-            runner.is_admin = False
             runner.check_is_admin = MagicMock(return_value=False)
             with self.assertRaisesRegex(
                 AuthError,
@@ -1143,7 +1138,6 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
                 print("Exception raised is", error)
 
             print("Test case 2C. Same as above but with FAKE_TEST_USER + ADMIN) ")
-            runner.is_admin = True
             runner.check_is_admin = MagicMock(return_value=True)
             job_state = runner.check_jobs_date_range_for_user(
                 creation_end_time=str(tomorrow),

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -956,8 +956,6 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         # fixed_rj = RunJob(runner)
         # fixed_rj._get_module_git_commit = MagicMock(return_value='hash_goes_here')
 
-        runner._get_module_git_commit = MagicMock(return_value="git_commit_goes_here")
-
         runner.get_condor = MagicMock(return_value=condor_mock)
         # ctx = {"user_id": self.user_id, "wsid": self.ws_id, "token": self.token}
         job = get_example_job().to_mongo().to_dict()


### PR DESCRIPTION
# Description of PR purpose/changes

Remove the `SDKMR.is_admin` field, which is not actually used anywhere.
Remove a couple of mocked fields on SDKMR that don't actually exist.

# Jira Ticket / Github Issue #
- [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
