### PR TITLE
DATAUP-389 - Add sdkmr.save_and_return_job

### DIFF
--- a/lib/execution_engine2/sdk/SDKMethodRunner.py
+++ b/lib/execution_engine2/sdk/SDKMethodRunner.py
@@ -248,12 +248,19 @@ class SDKMethodRunner:
     # at this point since MongoEngine creates a global connection to MongoDB
     # and makes it available to all the model objects.
 
-    def save_job(self, job: Job):
+    def save_job(self, job: Job) -> str:
         """
-        Save a job record to the Mongo database.
+        Save a job record to the Mongo database and return the job's ID as a string.
         """
         job.save()
         return str(job.id)
+
+    def save_and_return_job(self, job: Job) -> Job:
+        """
+        Save a job record to the Mongo database and return the updated job.
+        """
+        job.save()
+        return job
 
     def get_job_counts(self, job_filter):
         """

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -195,6 +195,18 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
 
         j.save.assert_called_once_with()
 
+    def test_save_and_return_job(self):
+        ws = Workspace("https://fake.com")
+        wsa = WorkspaceAuth("user", ws)
+        cliset = UserClientSet("user", "token", ws, wsa)
+        clients_and_mocks = get_client_mocks(self.cfg, self.config_file, *ALL_CLIENTS)
+        sdkmr = SDKMethodRunner(cliset, clients_and_mocks[ClientSet])
+
+        j = create_autospec(Job, spec_set=True, instance=True)
+        assert sdkmr.save_and_return_job(j) == j
+
+        j.save.assert_called_once_with()
+
     # Status
     @patch("lib.execution_engine2.utils.Condor.Condor", autospec=True)
     def test_cancel_job(self, condor):


### PR DESCRIPTION
# Description of PR purpose/changes

Needed for mocking the case where a Job object has the save() method
called on it and is then continued to be used. The save() method has a
side effect of modifying the Job object to add an `.id` field, and so to
mock that the method that calls save() on the job must return the updated job.

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
