### PR TITLE
DATAUP-389 - refactor RunJob unit tests

### DIFF
--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -80,7 +80,9 @@ def _set_up_common_return_values(mocks):
     """
     Set up return values on mocks that are the same for several tests.
     """
-    mocks[Workspace].get_object_info3.return_value = {"paths": [[_WS_REF_1], [_WS_REF_2]]}
+    mocks[Workspace].get_object_info3.return_value = {
+        "paths": [[_WS_REF_1], [_WS_REF_2]]
+    }
     mocks[SDKMethodRunner].save_job.return_value = _JOB_ID
     mocks[Catalog].get_module_version.return_value = {"git_commit_hash": _GIT_COMMIT}
     mocks[Condor].run_job.return_value = SubmissionInfo(_CLUSTER, {}, None)
@@ -139,7 +141,9 @@ def _check_common_mock_calls(mocks, reqs, creqs, wsid):
         "token": _TOKEN,
         "cg_resources_requirements": reqs,
     }
-    mocks[Condor].run_job.assert_called_once_with(params=params_expected, concierge_params=None)
+    mocks[Condor].run_job.assert_called_once_with(
+        params=params_expected, concierge_params=None
+    )
 
     # updated job data save
     mocks[MongoUtil].get_job.assert_called_once_with(_JOB_ID)


### PR DESCRIPTION
# Description of PR purpose/changes

Factors out some mocking that will be in common with other tests once
the job requirements resolution code will be integrated. Should make the
upcoming changes easier to understand.

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
