### PR TITLE
DATAUP-389 - check that source_ws_objects is a list

### DIFF
--- a/lib/execution_engine2/sdk/job_submission_parameters.py
+++ b/lib/execution_engine2/sdk/job_submission_parameters.py
@@ -214,6 +214,8 @@ class JobSubmissionParameters:
         )
         self.wsid = _gt_zero(wsid, "wsid", optional=True)
         source_ws_objects = source_ws_objects if source_ws_objects else []
+        if type(source_ws_objects) != list:
+            raise IncorrectParamsException("source_ws_objects must be a list")
         for i, ref in enumerate(source_ws_objects):
             upa, is_valid = _is_valid_UPA(ref)
             if not is_valid:

--- a/test/tests_for_sdkmr/job_submission_parameters_test.py
+++ b/test/tests_for_sdkmr/job_submission_parameters_test.py
@@ -529,6 +529,18 @@ def test_job_sub_init_fail():
         u,
         n,
         n,
+        {"1/2/3": "5/6/7"},
+        IncorrectParamsException(
+            "source_ws_objects must be a list"
+        ),
+    )
+    _job_sub_init_fail(
+        j,
+        a,
+        r,
+        u,
+        n,
+        n,
         ["1/2/3", "   \t  "],
         IncorrectParamsException(
             "source_ws_objects index 1, '   \t  ', is not a valid Unique Permanent Address"

--- a/test/tests_for_sdkmr/job_submission_parameters_test.py
+++ b/test/tests_for_sdkmr/job_submission_parameters_test.py
@@ -530,9 +530,7 @@ def test_job_sub_init_fail():
         n,
         n,
         {"1/2/3": "5/6/7"},
-        IncorrectParamsException(
-            "source_ws_objects must be a list"
-        ),
+        IncorrectParamsException("source_ws_objects must be a list"),
     )
     _job_sub_init_fail(
         j,


### PR DESCRIPTION
# Description of PR purpose/changes

Mypy should really be used for that check, but it turns out this class will be the first thing to encounter s_ws_o, so in the interests of utility sticking the check in there.

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
