### PR TITLE
DATAUP-389 - don't allow users to set a job's parent job

### DIFF
--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -299,8 +299,7 @@ class EE2RunJob:
     def _run_batch(self, parent_job: Job, params):
         child_jobs = []
         for job_param in params:
-            if _PARENT_JOB_ID not in job_param:
-                job_param[_PARENT_JOB_ID] = str(parent_job.id)
+            job_param[_PARENT_JOB_ID] = str(parent_job.id)
             try:
                 child_jobs.append(str(self._run(params=job_param)))
             except Exception as e:


### PR DESCRIPTION
# Description of PR purpose/changes

Not necessary and allows setting a job's parent to an arbitrary job, which is not what we want. Confirmed with @bio-boris 

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k+ warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
