### PR TITLE
DATAUP-389 - Add workspace instance to integration tests

### DIFF
--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -150,6 +150,7 @@ def ws_controller(config, mongo_client, auth_url):
     ws_mongo_user = "workspace"
     # clean up from any previously failed test runs that left the db in place
     _clean_db(mongo_client, ws_db, ws_mongo_user)
+    _clean_db(mongo_client, ws_types_db, ws_mongo_user)
 
     # make a user for the ws dbs
     _create_db_user(mongo_client, ws_db, ws_mongo_user, "wspwd")

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -89,9 +89,7 @@ def _clean_db(mongo_client, db, db_user):
 
 
 def _create_db_user(mongo_client, db, db_user, password):
-    mongo_client[db].command(
-        "createUser", db_user, pwd=password, roles=["readWrite"]
-    )
+    mongo_client[db].command("createUser", db_user, pwd=password, roles=["readWrite"])
 
 
 def _set_up_auth_users(auth_url):
@@ -208,9 +206,7 @@ def _update_config_and_create_config_file(full_config, auth_url, ws_controller):
 
 
 def _clear_dbs(
-    mc: pymongo.MongoClient,
-    config: Dict[str, str],
-    ws_controller: WorkspaceController
+    mc: pymongo.MongoClient, config: Dict[str, str], ws_controller: WorkspaceController
 ):
     ee2 = mc[config["mongo-database"]]
     for name in ee2.list_collection_names():
@@ -224,7 +220,9 @@ def _clear_dbs(
 def service(full_config, auth_url, mongo_client, config, ws_controller):
     # also updates the config in place so it contains the correct auth urls for any other
     # methods that use the config fixture
-    cfgpath = _update_config_and_create_config_file(full_config, auth_url, ws_controller)
+    cfgpath = _update_config_and_create_config_file(
+        full_config, auth_url, ws_controller
+    )
     print(f"created test deploy at {cfgpath}")
     _clear_dbs(mongo_client, config, ws_controller)
 
@@ -290,4 +288,4 @@ def test_get_admin_permission_success(ee2_port):
 def test_temporary_check_ws(ee2_port, ws_controller):
     wsc = Workspace(ws_controller.get_url(), token=TOKEN_NO_ADMIN)
     ws = wsc.create_workspace({"workspace": "foo"})
-    assert ws[1] == 'foo'
+    assert ws[1] == "foo"

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -40,10 +40,6 @@ from installed_clients.execution_engine2Client import execution_engine2 as ee2cl
 from installed_clients.WorkspaceClient import Workspace
 
 KEEP_TEMP_FILES = False
-AUTH_DB = "api_to_db_auth_test"
-AUTH_MONGO_USER = "auth"
-WS_DB = "api_to_db_ws_test"
-WS_MONGO_USER = "workspace"
 TEMP_DIR = Path("test_temp_can_delete")
 
 # may need to make this configurable
@@ -113,18 +109,20 @@ def _set_up_auth_users(auth_url):
 
 @fixture(scope="module")
 def auth_url(config, mongo_client):
+    auth_db = "api_to_db_auth_test"
+    auth_mongo_user = "auth"
     # clean up from any previously failed test runs that left the db in place
-    _clean_db(mongo_client, AUTH_DB, AUTH_MONGO_USER)
+    _clean_db(mongo_client, auth_db, auth_mongo_user)
 
     # make a user for the auth db
-    _create_db_user(mongo_client, AUTH_DB, AUTH_MONGO_USER, "authpwd")
+    _create_db_user(mongo_client, auth_db, auth_mongo_user, "authpwd")
 
     auth = AuthController(
         JARS_DIR,
         config["mongo-host"],
-        AUTH_DB,
+        auth_db,
         TEMP_DIR,
-        mongo_user=AUTH_MONGO_USER,
+        mongo_user=auth_mongo_user,
         mongo_pwd="authpwd",
     )
     print(
@@ -142,26 +140,29 @@ def auth_url(config, mongo_client):
 
     # Because the tests are run with mongo in a persistent docker container via docker-compose,
     # we need to clean up after ourselves.
-    _clean_db(mongo_client, AUTH_DB, AUTH_MONGO_USER)
+    _clean_db(mongo_client, auth_db, auth_mongo_user)
 
 
 @fixture(scope="module")
 def ws_controller(config, mongo_client, auth_url):
+    ws_db = "api_to_db_ws_test"
+    ws_types_db = "api_to_db_ws_types_test"
+    ws_mongo_user = "workspace"
     # clean up from any previously failed test runs that left the db in place
-    _clean_db(mongo_client, WS_DB, WS_MONGO_USER)
+    _clean_db(mongo_client, ws_db, ws_mongo_user)
 
     # make a user for the ws dbs
-    _create_db_user(mongo_client, WS_DB, WS_MONGO_USER, "wspwd")
-    _create_db_user(mongo_client, "api_to_db_ws_types_test", WS_MONGO_USER, "wspwd")
+    _create_db_user(mongo_client, ws_db, ws_mongo_user, "wspwd")
+    _create_db_user(mongo_client, ws_types_db, ws_mongo_user, "wspwd")
 
     ws = WorkspaceController(
         JARS_DIR,
         config["mongo-host"],
-        WS_DB,
-        "api_to_db_ws_types_test",
+        ws_db,
+        ws_types_db,
         auth_url + "/testmode/",
         TEMP_DIR,
-        mongo_user=WS_MONGO_USER,
+        mongo_user=ws_mongo_user,
         mongo_pwd="wspwd",
     )
     print(
@@ -175,8 +176,8 @@ def ws_controller(config, mongo_client, auth_url):
 
     # Because the tests are run with mongo in a persistent docker container via docker-compose,
     # we need to clean up after ourselves.
-    _clean_db(mongo_client, WS_DB, WS_MONGO_USER)
-    _clean_db(mongo_client, "api_to_db_ws_types_test", WS_MONGO_USER)
+    _clean_db(mongo_client, ws_db, ws_mongo_user)
+    _clean_db(mongo_client, ws_types_db, ws_mongo_user)
 
 
 def _update_config_and_create_config_file(full_config, auth_url, ws_controller):

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -5,9 +5,11 @@ NOTE 1: These tests are designed to only be runnable after running docker-compos
 
 NOTE 2: These tests were set up quickly in order to debug a problem with administration related
 calls. As such, the auth server was set up to run in test mode locally. If more integrations
-(e.g. the workspace) are needed, they will need to be added either locally or as docker containers.
-If the latter, the test auth integration will likely need to be converted to a docker container or
-exposed to other containers.
+are needed, they will need to be added either locally or as docker containers.
+If the latter, the test auth and workspace integrations will likely need to be converted to
+docker containers or exposed to other containers.
+
+NOTE 3: Posting to Slack always fails silently.
 """
 
 import os
@@ -21,6 +23,7 @@ import pymongo
 from pytest import fixture
 from typing import Dict
 from tests_for_integration.auth_controller import AuthController
+from tests_for_integration.workspace_controller import WorkspaceController
 from utils_shared.test_utils import (
     get_full_test_config,
     get_ee2_test_config,
@@ -34,10 +37,13 @@ from utils_shared.test_utils import (
 )
 from execution_engine2.sdk.EE2Constants import ADMIN_READ_ROLE, ADMIN_WRITE_ROLE
 from installed_clients.execution_engine2Client import execution_engine2 as ee2client
+from installed_clients.WorkspaceClient import Workspace
 
 KEEP_TEMP_FILES = False
-AUTH_DB = "api_to_db_test"
+AUTH_DB = "api_to_db_auth_test"
 AUTH_MONGO_USER = "auth"
+WS_DB = "api_to_db_ws_test"
+WS_MONGO_USER = "workspace"
 TEMP_DIR = Path("test_temp_can_delete")
 
 # may need to make this configurable
@@ -73,13 +79,19 @@ def mongo_client(config):
     mc.close()
 
 
-def _clean_auth_db(mongo_client):
+def _clean_db(mongo_client, db, db_user):
     try:
-        mongo_client[AUTH_DB].command("dropUser", AUTH_MONGO_USER)
+        mongo_client[db].command("dropUser", db_user)
     except pymongo.errors.OperationFailure as e:
-        if f"User '{AUTH_MONGO_USER}@{AUTH_DB}' not found" not in e.args[0]:
+        if f"User '{db_user}@{db}' not found" not in e.args[0]:
             raise  # otherwise ignore and continue, user is already toast
-    mongo_client.drop_database(AUTH_DB)
+    mongo_client.drop_database(db)
+
+
+def _create_db_user(mongo_client, db, db_user, password):
+    mongo_client[db].command(
+        "createUser", db_user, pwd=password, roles=["readWrite"]
+    )
 
 
 def _set_up_auth_users(auth_url):
@@ -104,12 +116,11 @@ def _set_up_auth_users(auth_url):
 @fixture(scope="module")
 def auth_url(config, mongo_client):
     # clean up from any previously failed test runs that left the db in place
-    _clean_auth_db(mongo_client)
+    _clean_db(mongo_client, AUTH_DB, AUTH_MONGO_USER)
 
     # make a user for the auth db
-    mongo_client[AUTH_DB].command(
-        "createUser", AUTH_MONGO_USER, pwd="authpwd", roles=["readWrite"]
-    )
+    _create_db_user(mongo_client, AUTH_DB, AUTH_MONGO_USER, "authpwd")
+
     auth = AuthController(
         JARS_DIR,
         config["mongo-host"],
@@ -133,10 +144,44 @@ def auth_url(config, mongo_client):
 
     # Because the tests are run with mongo in a persistent docker container via docker-compose,
     # we need to clean up after ourselves.
-    _clean_auth_db(mongo_client)
+    _clean_db(mongo_client, AUTH_DB, AUTH_MONGO_USER)
 
 
-def _update_config_and_create_config_file(full_config, auth_url):
+@fixture(scope="module")
+def ws_controller(config, mongo_client, auth_url):
+    # clean up from any previously failed test runs that left the db in place
+    _clean_db(mongo_client, WS_DB, WS_MONGO_USER)
+
+    # make a user for the ws dbs
+    _create_db_user(mongo_client, WS_DB, WS_MONGO_USER, "wspwd")
+    _create_db_user(mongo_client, "api_to_db_ws_types_test", WS_MONGO_USER, "wspwd")
+
+    ws = WorkspaceController(
+        JARS_DIR,
+        config["mongo-host"],
+        WS_DB,
+        "api_to_db_ws_types_test",
+        auth_url + "/testmode/",
+        TEMP_DIR,
+        mongo_user=WS_MONGO_USER,
+        mongo_pwd="wspwd",
+    )
+    print(
+        f"Started KBase Workspace {ws.version} on port {ws.port} "
+        + f"in dir {ws.temp_dir} in {ws.startup_count}s"
+    )
+    yield ws
+
+    print(f"shutting down workspace, KEEP_TEMP_FILES={KEEP_TEMP_FILES}")
+    ws.destroy(not KEEP_TEMP_FILES)
+
+    # Because the tests are run with mongo in a persistent docker container via docker-compose,
+    # we need to clean up after ourselves.
+    _clean_db(mongo_client, WS_DB, WS_MONGO_USER)
+    _clean_db(mongo_client, "api_to_db_ws_types_test", WS_MONGO_USER)
+
+
+def _update_config_and_create_config_file(full_config, auth_url, ws_controller):
     """
     Updates the config in place with the correct auth url for the tests and
     writes the updated config to a temporary file.
@@ -151,6 +196,7 @@ def _update_config_and_create_config_file(full_config, auth_url):
     ee2c["auth-service-url-v2"] = auth_url + "/testmode/api/v2/token"
     ee2c["auth-url"] = auth_url + "/testmode"
     ee2c["auth-service-url-allow-insecure"] = "true"
+    ee2c["workspace-url"] = f"http://localhost:{ws_controller.port}"
 
     deploy = tempfile.mkstemp(".cfg", "deploy-", dir=TEMP_DIR, text=True)
     os.close(deploy[0])
@@ -161,21 +207,26 @@ def _update_config_and_create_config_file(full_config, auth_url):
     return deploy[1]
 
 
-def _clear_ee2_db(mc: pymongo.MongoClient, config: Dict[str, str]):
+def _clear_dbs(
+    mc: pymongo.MongoClient,
+    config: Dict[str, str],
+    ws_controller: WorkspaceController
+):
     ee2 = mc[config["mongo-database"]]
     for name in ee2.list_collection_names():
         if not name.startswith("system."):
             # don't drop collection since that drops indexes
             ee2.get_collection(name).delete_many({})
+    ws_controller.clear_db()
 
 
 @fixture(scope="module")
-def service(full_config, auth_url, mongo_client, config):
+def service(full_config, auth_url, mongo_client, config, ws_controller):
     # also updates the config in place so it contains the correct auth urls for any other
     # methods that use the config fixture
-    cfgpath = _update_config_and_create_config_file(full_config, auth_url)
+    cfgpath = _update_config_and_create_config_file(full_config, auth_url, ws_controller)
     print(f"created test deploy at {cfgpath}")
-    _clear_ee2_db(mongo_client, config)
+    _clear_dbs(mongo_client, config, ws_controller)
 
     prior_deploy = os.environ[KB_DEPLOY_ENV]
     # from this point on, calling the get_*_test_config methods will get the temp config file
@@ -209,8 +260,8 @@ def service(full_config, auth_url, mongo_client, config):
 
 
 @fixture
-def ee2_port(service, mongo_client, config):
-    _clear_ee2_db(mongo_client, config)
+def ee2_port(service, mongo_client, config, ws_controller):
+    _clear_dbs(mongo_client, config, ws_controller)
 
     yield service
 
@@ -234,3 +285,9 @@ def test_get_admin_permission_success(ee2_port):
     assert ee2cli_read.get_admin_permission() == {"permission": "r"}
     assert ee2cli_no.get_admin_permission() == {"permission": "n"}
     assert ee2cli_write.get_admin_permission() == {"permission": "w"}
+
+
+def test_temporary_check_ws(ee2_port, ws_controller):
+    wsc = Workspace(ws_controller.get_url(), token=TOKEN_NO_ADMIN)
+    ws = wsc.create_workspace({"workspace": "foo"})
+    assert ws[1] == 'foo'

--- a/test/tests_for_integration/workspace_controller.py
+++ b/test/tests_for_integration/workspace_controller.py
@@ -1,0 +1,234 @@
+'''
+Q&D Utility to run a Workspace server for the purposes of testing.
+
+Initializes a GridFS backend and does not support handles, bytestreams or samples.
+'''
+
+import os as _os
+import shutil as _shutil
+import subprocess as _subprocess
+import tempfile as _tempfile
+import time as _time
+from pathlib import Path as _Path
+from pymongo.mongo_client import MongoClient
+
+import requests as _requests
+
+from configparser import ConfigParser as _ConfigParser
+from installed_clients.WorkspaceClient import Workspace as _Workspace
+from installed_clients.baseclient import ServerError as _ServerError
+
+from utils_shared.test_utils import TestException as _TestException
+from utils_shared import test_utils as _test_utils
+
+_WS_CLASS = 'us.kbase.workspace.WorkspaceServer'
+_JARS_FILE = _Path(__file__).resolve().parent.joinpath('wsjars')
+
+
+class WorkspaceController:
+    """
+    The main Workspace controller class. The Workspace will allow users with the KBase Auth
+    service WS_READ_ADMIN role to use read-only administration methods and WS_FULL_ADMIN role
+    to use all administration methods.
+
+    Attributes:
+    version - the version of the Workspace service
+    port - the port for the Workspace service.
+    temp_dir - the location of the Workspace data and logs.
+    """
+
+    # TODO This code likely belongs somewhere else. Not quite sure where though, maybe in WS repo.
+    # TODO This code is similar to the auth controller code, DRY it up?
+
+    def __init__(
+            self,
+            jars_dir: _Path,
+            mongo_host: str,
+            mongo_db: str,
+            mongo_type_db: str,
+            auth_url: str,
+            root_temp_dir: _Path,
+            mongo_user: str = None,
+            mongo_pwd: str = None):
+        '''
+        Create and start a new Workspace service. An unused port will be selected for the server.
+
+        :param jars_dir: The path to the lib/jars dir of the KBase Jars repo
+            (https://github.com/kbase/jars), e.g /path_to_repo/lib/jars.
+        :param mongo_host: The address for the MongoDB host.
+        :param mongo_db: The database in which to store Workspace data.
+        :param mongo_type_db: The database in which to store Workspace type specifications.
+        :param auth_url: The root url of an instance of the KBase auth service.
+        :param root_temp_dir: A temporary directory in which to store Auth data and log files.
+            The files will be stored inside a child directory that is unique per invocation.
+        :param mongo_user: The username for the Mongo account, if provided. The user is expected
+            to be a user in the provided databases with readWrite permission.
+        :param mongo_pwd: The password for the Mongo accont if, provided.
+        '''
+        if not jars_dir or not _os.access(jars_dir, _os.X_OK):
+            raise _TestException('jars_dir {} does not exist or is not executable.'
+                                 .format(jars_dir))
+        if not mongo_host:
+            raise _TestException('mongo_controller must be provided')
+        if not mongo_db:
+            raise _TestException('mongo_db must be provided')
+        if not mongo_type_db:
+            raise _TestException('mongo_type_db must be provided')
+        if not auth_url:
+            raise _TestException('auth_url must be provided')
+        if not root_temp_dir:
+            raise _TestException('root_temp_dir is None')
+        if bool(mongo_user) ^ bool(mongo_pwd):  # xor
+            raise _TestException(
+                "Neither or both of mongo_user and mongo_pwd is required"
+            )
+
+        self._db = mongo_db
+        jars_dir = jars_dir.resolve()
+        class_path = self._get_class_path(jars_dir)
+
+        # make temp dirs
+        root_temp_dir = root_temp_dir.absolute()
+        _os.makedirs(root_temp_dir, exist_ok=True)
+        self.temp_dir = _Path(
+            _tempfile.mkdtemp(prefix='WorkspaceController-', dir=str(root_temp_dir)))
+        ws_temp_dir = self.temp_dir.joinpath('temp_files')
+        _os.makedirs(ws_temp_dir)
+
+        configfile = self._create_deploy_cfg(
+            self.temp_dir,
+            ws_temp_dir,
+            mongo_host,
+            mongo_db,
+            mongo_type_db,
+            auth_url,
+            mongo_user,
+            mongo_pwd)
+        newenv = _os.environ.copy()
+        newenv['KB_DEPLOYMENT_CONFIG'] = configfile
+
+        self.port = _test_utils.find_free_port()
+
+        command = ['java', '-classpath', class_path, _WS_CLASS, str(self.port)]
+
+        self._wslog = self.temp_dir / 'ws.log'
+        self._outfile = open(self._wslog, 'w')
+
+        self._proc = _subprocess.Popen(
+            command, stdout=self._outfile, stderr=_subprocess.STDOUT, env=newenv)
+
+        ws = _Workspace(f'http://localhost:{self.port}')
+        for count in range(40):
+            err = None
+            _time.sleep(1)  # wait for server to start
+            try:
+                self.version = ws.ver()
+                break
+            except (_ServerError, _requests.exceptions.ConnectionError) as se:
+                err = _TestException(se.args[0])
+                err.__cause__ = se
+        if err:
+            print('Error starting workspace service. Dumping logs and throwing error')
+            self._print_ws_logs()
+            raise err
+        self.startup_count = count + 1
+        if mongo_user:
+            self._mongo_client = MongoClient(
+                mongo_host,
+                username=mongo_user,
+                password=mongo_pwd,
+                authSource=mongo_db)
+        else:
+            self._mongo_client = MongoClient(mongo_host)
+        # check that the client is correctly connected. See
+        # https://api.mongodb.com/python/3.7.0/api/pymongo/mongo_client.html
+        #    #pymongo.mongo_client.MongoClient
+        self._mongo_client.admin.command('ismaster')
+
+    def _get_class_path(self, jars_dir: _Path):
+        cp = []
+        with open(_JARS_FILE) as jf:
+            for line in jf:
+                if line.strip() and not line.startswith('#'):
+                    p = jars_dir.joinpath(line.strip())
+                    if not p.is_file():
+                        raise _TestException(f'Required jar does not exist: {p}')
+                    cp.append(str(p))
+        return ':'.join(cp)
+
+    def _create_deploy_cfg(
+            self,
+            temp_dir,
+            ws_temp_dir,
+            mongo_host,
+            mongo_db,
+            mongo_type_db,
+            auth_url,
+            mongo_user,
+            mongo_pwd):
+        cp = _ConfigParser()
+        cp['Workspace'] = {
+            'mongodb-host': mongo_host,
+            'mongodb-database': mongo_db,
+            'mongodb-type-database': mongo_type_db,
+            'backend-type': 'GridFS',
+            'auth-service-url': auth_url + '/api/legacy/KBase',
+            'auth-service-url-allow-insecure': 'true',
+            # TODO WS trailing slash should not be necessary
+            # see https://github.com/kbase/workspace_deluxe/issues/350
+            'auth2-service-url': auth_url + '/',
+            'temp-dir': str(ws_temp_dir),
+            'ignore-handle-service': 'true',
+            'auth2-ws-admin-read-only-roles': 'WS_READ_ADMIN',
+            'auth2-ws-admin-full-roles': 'WS_FULL_ADMIN'
+        }
+        if mongo_user:
+            cp['Workspace']['mongodb-user'] = mongo_user
+            cp['Workspace']['mongodb-pwd'] = mongo_pwd
+        f = temp_dir / 'test.cfg'
+        with open(f, 'w') as inifile:
+            cp.write(inifile)
+        return f
+
+    def get_url(self):
+        '''
+        Get the url for the running workspace instance.
+        '''
+        return f'http://localhost:{self.port}'
+
+    def clear_db(self):
+        '''
+        Remove all data, but not indexes, from the database. Do not remove any installed types.
+        '''
+        db = self._mongo_client[self._db]
+        for name in db.list_collection_names():
+            if not name.startswith('system.'):
+                # don't drop collection since that drops indexes
+                db.get_collection(name).delete_many({})
+
+    def destroy(self, delete_temp_files: bool = True, dump_logs_to_stdout: bool = True):
+        '''
+        Shut down the server and optionally delete any files generated.
+
+        :param delete_temp_files: if true, delete all the temporary files generated as part of
+            running the server.
+        :param dump_logs_to_stdout: Write the contents of the workspace log file to stdout.
+            This is useful in the context of 3rd party CI services, where the log file is not
+            necessarily accessible.
+        '''
+        if self._proc:
+            self._proc.terminate()
+        self._print_ws_logs(dump_logs_to_stdout=dump_logs_to_stdout)
+        if delete_temp_files and self.temp_dir:
+            _shutil.rmtree(self.temp_dir)
+        if self._mongo_client:
+            self._mongo_client.close()
+
+    # closes logfile
+    def _print_ws_logs(self, dump_logs_to_stdout=True):
+        if self._outfile:
+            self._outfile.close()
+            if dump_logs_to_stdout:
+                with open(self._wslog) as f:
+                    for line in f:
+                        print(line)

--- a/test/tests_for_integration/workspace_controller.py
+++ b/test/tests_for_integration/workspace_controller.py
@@ -1,8 +1,8 @@
-'''
+"""
 Q&D Utility to run a Workspace server for the purposes of testing.
 
 Initializes a GridFS backend and does not support handles, bytestreams or samples.
-'''
+"""
 
 import os as _os
 import shutil as _shutil
@@ -21,8 +21,8 @@ from installed_clients.baseclient import ServerError as _ServerError
 from utils_shared.test_utils import TestException as _TestException
 from utils_shared import test_utils as _test_utils
 
-_WS_CLASS = 'us.kbase.workspace.WorkspaceServer'
-_JARS_FILE = _Path(__file__).resolve().parent.joinpath('wsjars')
+_WS_CLASS = "us.kbase.workspace.WorkspaceServer"
+_JARS_FILE = _Path(__file__).resolve().parent.joinpath("wsjars")
 
 
 class WorkspaceController:
@@ -41,16 +41,17 @@ class WorkspaceController:
     # TODO This code is similar to the auth controller code, DRY it up?
 
     def __init__(
-            self,
-            jars_dir: _Path,
-            mongo_host: str,
-            mongo_db: str,
-            mongo_type_db: str,
-            auth_url: str,
-            root_temp_dir: _Path,
-            mongo_user: str = None,
-            mongo_pwd: str = None):
-        '''
+        self,
+        jars_dir: _Path,
+        mongo_host: str,
+        mongo_db: str,
+        mongo_type_db: str,
+        auth_url: str,
+        root_temp_dir: _Path,
+        mongo_user: str = None,
+        mongo_pwd: str = None,
+    ):
+        """
         Create and start a new Workspace service. An unused port will be selected for the server.
 
         :param jars_dir: The path to the lib/jars dir of the KBase Jars repo
@@ -64,20 +65,21 @@ class WorkspaceController:
         :param mongo_user: The username for the Mongo account, if provided. The user is expected
             to be a user in the provided databases with readWrite permission.
         :param mongo_pwd: The password for the Mongo accont if, provided.
-        '''
+        """
         if not jars_dir or not _os.access(jars_dir, _os.X_OK):
-            raise _TestException('jars_dir {} does not exist or is not executable.'
-                                 .format(jars_dir))
+            raise _TestException(
+                "jars_dir {} does not exist or is not executable.".format(jars_dir)
+            )
         if not mongo_host:
-            raise _TestException('mongo_controller must be provided')
+            raise _TestException("mongo_controller must be provided")
         if not mongo_db:
-            raise _TestException('mongo_db must be provided')
+            raise _TestException("mongo_db must be provided")
         if not mongo_type_db:
-            raise _TestException('mongo_type_db must be provided')
+            raise _TestException("mongo_type_db must be provided")
         if not auth_url:
-            raise _TestException('auth_url must be provided')
+            raise _TestException("auth_url must be provided")
         if not root_temp_dir:
-            raise _TestException('root_temp_dir is None')
+            raise _TestException("root_temp_dir is None")
         if bool(mongo_user) ^ bool(mongo_pwd):  # xor
             raise _TestException(
                 "Neither or both of mongo_user and mongo_pwd is required"
@@ -91,8 +93,9 @@ class WorkspaceController:
         root_temp_dir = root_temp_dir.absolute()
         _os.makedirs(root_temp_dir, exist_ok=True)
         self.temp_dir = _Path(
-            _tempfile.mkdtemp(prefix='WorkspaceController-', dir=str(root_temp_dir)))
-        ws_temp_dir = self.temp_dir.joinpath('temp_files')
+            _tempfile.mkdtemp(prefix="WorkspaceController-", dir=str(root_temp_dir))
+        )
+        ws_temp_dir = self.temp_dir.joinpath("temp_files")
         _os.makedirs(ws_temp_dir)
 
         configfile = self._create_deploy_cfg(
@@ -103,21 +106,23 @@ class WorkspaceController:
             mongo_type_db,
             auth_url,
             mongo_user,
-            mongo_pwd)
+            mongo_pwd,
+        )
         newenv = _os.environ.copy()
-        newenv['KB_DEPLOYMENT_CONFIG'] = configfile
+        newenv["KB_DEPLOYMENT_CONFIG"] = configfile
 
         self.port = _test_utils.find_free_port()
 
-        command = ['java', '-classpath', class_path, _WS_CLASS, str(self.port)]
+        command = ["java", "-classpath", class_path, _WS_CLASS, str(self.port)]
 
-        self._wslog = self.temp_dir / 'ws.log'
-        self._outfile = open(self._wslog, 'w')
+        self._wslog = self.temp_dir / "ws.log"
+        self._outfile = open(self._wslog, "w")
 
         self._proc = _subprocess.Popen(
-            command, stdout=self._outfile, stderr=_subprocess.STDOUT, env=newenv)
+            command, stdout=self._outfile, stderr=_subprocess.STDOUT, env=newenv
+        )
 
-        ws = _Workspace(f'http://localhost:{self.port}')
+        ws = _Workspace(f"http://localhost:{self.port}")
         for count in range(40):
             err = None
             _time.sleep(1)  # wait for server to start
@@ -128,86 +133,85 @@ class WorkspaceController:
                 err = _TestException(se.args[0])
                 err.__cause__ = se
         if err:
-            print('Error starting workspace service. Dumping logs and throwing error')
+            print("Error starting workspace service. Dumping logs and throwing error")
             self._print_ws_logs()
             raise err
         self.startup_count = count + 1
         if mongo_user:
             self._mongo_client = MongoClient(
-                mongo_host,
-                username=mongo_user,
-                password=mongo_pwd,
-                authSource=mongo_db)
+                mongo_host, username=mongo_user, password=mongo_pwd, authSource=mongo_db
+            )
         else:
             self._mongo_client = MongoClient(mongo_host)
         # check that the client is correctly connected. See
         # https://api.mongodb.com/python/3.7.0/api/pymongo/mongo_client.html
         #    #pymongo.mongo_client.MongoClient
-        self._mongo_client.admin.command('ismaster')
+        self._mongo_client.admin.command("ismaster")
 
     def _get_class_path(self, jars_dir: _Path):
         cp = []
         with open(_JARS_FILE) as jf:
             for line in jf:
-                if line.strip() and not line.startswith('#'):
+                if line.strip() and not line.startswith("#"):
                     p = jars_dir.joinpath(line.strip())
                     if not p.is_file():
-                        raise _TestException(f'Required jar does not exist: {p}')
+                        raise _TestException(f"Required jar does not exist: {p}")
                     cp.append(str(p))
-        return ':'.join(cp)
+        return ":".join(cp)
 
     def _create_deploy_cfg(
-            self,
-            temp_dir,
-            ws_temp_dir,
-            mongo_host,
-            mongo_db,
-            mongo_type_db,
-            auth_url,
-            mongo_user,
-            mongo_pwd):
+        self,
+        temp_dir,
+        ws_temp_dir,
+        mongo_host,
+        mongo_db,
+        mongo_type_db,
+        auth_url,
+        mongo_user,
+        mongo_pwd,
+    ):
         cp = _ConfigParser()
-        cp['Workspace'] = {
-            'mongodb-host': mongo_host,
-            'mongodb-database': mongo_db,
-            'mongodb-type-database': mongo_type_db,
-            'backend-type': 'GridFS',
-            'auth-service-url': auth_url + '/api/legacy/KBase',
-            'auth-service-url-allow-insecure': 'true',
+        cp["Workspace"] = {
+            "mongodb-host": mongo_host,
+            "mongodb-database": mongo_db,
+            "mongodb-type-database": mongo_type_db,
+            "backend-type": "GridFS",
+            "auth-service-url": auth_url + "/api/legacy/KBase",
+            "auth-service-url-allow-insecure": "true",
             # TODO WS trailing slash should not be necessary
             # see https://github.com/kbase/workspace_deluxe/issues/350
-            'auth2-service-url': auth_url + '/',
-            'temp-dir': str(ws_temp_dir),
-            'ignore-handle-service': 'true',
-            'auth2-ws-admin-read-only-roles': 'WS_READ_ADMIN',
-            'auth2-ws-admin-full-roles': 'WS_FULL_ADMIN'
+            "auth2-service-url": auth_url + "/",
+            "temp-dir": str(ws_temp_dir),
+            "ignore-handle-service": "true",
+            "auth2-ws-admin-read-only-roles": "WS_READ_ADMIN",
+            "auth2-ws-admin-full-roles": "WS_FULL_ADMIN",
         }
         if mongo_user:
-            cp['Workspace']['mongodb-user'] = mongo_user
-            cp['Workspace']['mongodb-pwd'] = mongo_pwd
-        f = temp_dir / 'test.cfg'
-        with open(f, 'w') as inifile:
+            cp["Workspace"]["mongodb-user"] = mongo_user
+            cp["Workspace"]["mongodb-pwd"] = mongo_pwd
+        f = temp_dir / "test.cfg"
+        with open(f, "w") as inifile:
             cp.write(inifile)
         return f
 
     def get_url(self):
-        '''
+        """
         Get the url for the running workspace instance.
-        '''
-        return f'http://localhost:{self.port}'
+        """
+        return f"http://localhost:{self.port}"
 
     def clear_db(self):
-        '''
+        """
         Remove all data, but not indexes, from the database. Do not remove any installed types.
-        '''
+        """
         db = self._mongo_client[self._db]
         for name in db.list_collection_names():
-            if not name.startswith('system.'):
+            if not name.startswith("system."):
                 # don't drop collection since that drops indexes
                 db.get_collection(name).delete_many({})
 
     def destroy(self, delete_temp_files: bool = True, dump_logs_to_stdout: bool = True):
-        '''
+        """
         Shut down the server and optionally delete any files generated.
 
         :param delete_temp_files: if true, delete all the temporary files generated as part of
@@ -215,7 +219,7 @@ class WorkspaceController:
         :param dump_logs_to_stdout: Write the contents of the workspace log file to stdout.
             This is useful in the context of 3rd party CI services, where the log file is not
             necessarily accessible.
-        '''
+        """
         if self._proc:
             self._proc.terminate()
         self._print_ws_logs(dump_logs_to_stdout=dump_logs_to_stdout)

--- a/test/tests_for_integration/wsjars
+++ b/test/tests_for_integration/wsjars
@@ -1,0 +1,40 @@
+kbase/workspace/WorkspaceService-0.11.2.jar
+
+# server code
+kbase/common/kbase-common-0.0.24.jar
+ini4j/ini4j-0.5.2.jar
+jetty/jetty-all-7.0.0.jar
+jna/jna-3.4.0.jar
+servlet/servlet-api-2.5.jar
+syslog4j/syslog4j-0.9.46.jar
+joda/joda-time-2.2.jar
+annotation/javax.annotation-api-1.3.2.jar
+
+junit/junit-4.12.jar
+hamcrest/hamcrest-core-1.3.jar
+kbase/auth/kbase-auth-0.4.4.jar
+jackson/jackson-annotations-2.2.3.jar
+jackson/jackson-core-2.2.3.jar
+jackson/jackson-databind-2.2.3.jar
+
+# shock client
+kbase/shock/shock-client-0.0.16.jar
+apache_commons/commons-logging-1.1.1.jar
+apache_commons/http/httpclient-4.3.1.jar
+apache_commons/http/httpcore-4.3.jar
+apache_commons/http/httpmime-4.3.1.jar
+	
+kbase/kidl/kbase-kidl-parser-1409261812-7863aef.jar
+apache_commons/commons-codec-1.8.jar
+apache_commons/commons-io-2.4.jar
+apache_commons/commons-lang3-3.1.jar
+mongo/mongo-java-driver-3.8.2.jar
+bson4jackson/bson4jackson-2.2.0-2.2.0.jar
+slf4j/slf4j-api-1.7.7.jar
+logback/logback-core-1.1.2.jar
+logback/logback-classic-1.1.2.jar
+google/guava-14.0.1.jar
+kafka/kafka-clients-2.1.0.jar
+kbase/handle/AbstractHandleClient-1.0.0.jar
+
+# leaving out S3 libs as this is a test instance of the WS and will save all data in GFS


### PR DESCRIPTION
# Description of PR purpose/changes

Adds the workspace service to the integration tests for use in future PRs.

# Jira Ticket / Github Issue #
- [X] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [X] Tests pass in Github Actions and locally 
- [X] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
