### PR TITLE
DATAUP-389 - add run_job integration test

### DIFF
--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -52,7 +52,7 @@ from utils_shared.test_utils import (
     create_auth_role,
     set_custom_roles,
     assert_close_to_now,
-    assert_exception_correct
+    assert_exception_correct,
 )
 from execution_engine2.sdk.EE2Constants import ADMIN_READ_ROLE, ADMIN_WRITE_ROLE
 from installed_clients.baseclient import ServerError
@@ -425,7 +425,9 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
         # set up the rest of the mocks
         _finish_htc_mocks(sub_init, schedd_init, sub, schedd, txn)
         sub.queue.return_value = 123
-        list_cgroups.return_value = [{"client_groups": ['{"request_cpus":8,"request_memory":5}']}]
+        list_cgroups.return_value = [
+            {"client_groups": ['{"request_cpus":8,"request_memory":5}']}
+        ]
         get_mod_ver.return_value = {"git_commit_hash": "somehash"}
 
         # run the method
@@ -439,13 +441,14 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "params": [{"foo": "bar"}, 42],
                 "service_ver": "beta",
                 "parent_job_id": "totallywrongid",
-                "meta": {"run_id": "rid",
-                         "token_id": "tid",
-                         "tag": "yourit",
-                         "cell_id": "cid",
-                         "status": "totally wasted bro",
-                         "thiskey": "getssilentlydropped",
-                         }
+                "meta": {
+                    "run_id": "rid",
+                    "token_id": "tid",
+                    "tag": "yourit",
+                    "cell_id": "cid",
+                    "status": "totally wasted bro",
+                    "thiskey": "getssilentlydropped",
+                },
             }
         )
 
@@ -508,7 +511,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
             "job_input": {
                 "wsid": 1,
                 "method": "mod.meth",
-                'params': [{'foo': 'bar'}, 42],
+                "params": [{"foo": "bar"}, 42],
                 "service_ver": "somehash",
                 "app_id": "mod/app",
                 "source_ws_objects": ["1/1/1", "1/2/1"],
@@ -525,7 +528,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                     "tag": "yourit",
                     "cell_id": "cid",
                     "status": "totally wasted bro",
-                }
+                },
             },
             "child_jobs": [],
             "batch_job": False,
@@ -538,8 +541,10 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
 def test_run_job_fail_no_workspace_access(ee2_port):
     params = {"method": "mod.meth", "app_id": "mod/app", "wsid": 1}
     # this error could probably use some cleanup
-    err = ("('An error occurred while fetching user permissions from the Workspace', "
-           + "ServerError('No workspace with id 1 exists'))")
+    err = (
+        "('An error occurred while fetching user permissions from the Workspace', "
+        + "ServerError('No workspace with id 1 exists'))"
+    )
     _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 
@@ -547,7 +552,7 @@ def test_run_job_fail_bad_method(ee2_port):
     params = {"method": "mod.meth.moke", "app_id": "mod/app"}
     # TODO the Server.py file is quoting strings for some reason it seems
     # see https://github.com/kbase/sample_service/blob/master/lib/SampleService/SampleServiceServer.py#L119-L127
-    err = '"Unrecognized method: \'mod.meth.moke\'. Please input module_name.function_name"'
+    err = "\"Unrecognized method: 'mod.meth.moke'. Please input module_name.function_name\""
     _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 
@@ -555,15 +560,19 @@ def test_run_job_fail_bad_app(ee2_port):
     params = {"method": "mod.meth", "app_id": "mod.app"}
     # TODO the Server.py file is quoting strings for some reason it seems
     # see https://github.com/kbase/sample_service/blob/master/lib/SampleService/SampleServiceServer.py#L119-L127
-    err = '"Application ID \'mod.app\' contains a \'.\'"'
+    err = "\"Application ID 'mod.app' contains a '.'\""
     _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 
 def test_run_job_fail_bad_upa(ee2_port):
-    params = {"method": "mod.meth", "app_id": "mod/app", "source_ws_objects": ["ws/obj/1"]}
+    params = {
+        "method": "mod.meth",
+        "app_id": "mod/app",
+        "source_ws_objects": ["ws/obj/1"],
+    }
     # TODO the Server.py file is quoting strings for some reason it seems
     # see https://github.com/kbase/sample_service/blob/master/lib/SampleService/SampleServiceServer.py#L119-L127
-    err = '"source_ws_objects index 0, \'ws/obj/1\', is not a valid Unique Permanent Address"'
+    err = "\"source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address\""
     _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -74,12 +74,12 @@ TOKEN_NO_ADMIN = None
 USER_WRITE_ADMIN = "writeuser"
 TOKEN_WRITE_ADMIN = None
 
-USER_WS_READ_ADMIN = 'wsreadadmin'
+USER_WS_READ_ADMIN = "wsreadadmin"
 TOKEN_WS_READ_ADMIN = None
-USER_WS_FULL_ADMIN = 'wsfulladmin'
+USER_WS_FULL_ADMIN = "wsfulladmin"
 TOKEN_WS_FULL_ADMIN = None
-WS_READ_ADMIN = 'WS_READ_ADMIN'
-WS_FULL_ADMIN = 'WS_FULL_ADMIN'
+WS_READ_ADMIN = "WS_READ_ADMIN"
+WS_FULL_ADMIN = "WS_FULL_ADMIN"
 
 CAT_GET_MODULE_VERSION = "installed_clients.CatalogClient.Catalog.get_module_version"
 CAT_LIST_CLIENT_GROUPS = (
@@ -136,27 +136,31 @@ def _set_up_auth_user(auth_url, user, display, roles=None):
 def _set_up_auth_users(auth_url):
     create_auth_role(auth_url, ADMIN_READ_ROLE, "ee2 admin read doohickey")
     create_auth_role(auth_url, ADMIN_WRITE_ROLE, "ee2 admin write thinger")
-    create_auth_role(auth_url, WS_READ_ADMIN, 'wsr')
-    create_auth_role(auth_url, WS_FULL_ADMIN, 'wsf')
+    create_auth_role(auth_url, WS_READ_ADMIN, "wsr")
+    create_auth_role(auth_url, WS_FULL_ADMIN, "wsf")
 
     global TOKEN_READ_ADMIN
     TOKEN_READ_ADMIN = _set_up_auth_user(
-        auth_url, USER_READ_ADMIN, "display1", [ADMIN_READ_ROLE])
+        auth_url, USER_READ_ADMIN, "display1", [ADMIN_READ_ROLE]
+    )
 
     global TOKEN_NO_ADMIN
     TOKEN_NO_ADMIN = _set_up_auth_user(auth_url, USER_NO_ADMIN, "display2")
 
     global TOKEN_WRITE_ADMIN
     TOKEN_WRITE_ADMIN = _set_up_auth_user(
-        auth_url, USER_WRITE_ADMIN, "display3", [ADMIN_WRITE_ROLE])
+        auth_url, USER_WRITE_ADMIN, "display3", [ADMIN_WRITE_ROLE]
+    )
 
     global TOKEN_WS_READ_ADMIN
     TOKEN_WS_READ_ADMIN = _set_up_auth_user(
-        auth_url, USER_WS_READ_ADMIN, "wsra", [WS_READ_ADMIN])
+        auth_url, USER_WS_READ_ADMIN, "wsra", [WS_READ_ADMIN]
+    )
 
     global TOKEN_WS_FULL_ADMIN
     TOKEN_WS_FULL_ADMIN = _set_up_auth_user(
-        auth_url, USER_WS_FULL_ADMIN, "wsrf", [WS_FULL_ADMIN])
+        auth_url, USER_WS_FULL_ADMIN, "wsrf", [WS_FULL_ADMIN]
+    )
 
 
 @fixture(scope="module")
@@ -196,22 +200,24 @@ def auth_url(config, mongo_client):
 
 
 def _add_ws_types(ws_controller):
-    wsc = Workspace(f'http://localhost:{ws_controller.port}', token=TOKEN_WS_FULL_ADMIN)
-    wsc.request_module_ownership('Trivial')
-    wsc.administer({'command': 'approveModRequest', 'module': 'Trivial'})
-    wsc.register_typespec({
-        'spec': '''
+    wsc = Workspace(f"http://localhost:{ws_controller.port}", token=TOKEN_WS_FULL_ADMIN)
+    wsc.request_module_ownership("Trivial")
+    wsc.administer({"command": "approveModRequest", "module": "Trivial"})
+    wsc.register_typespec(
+        {
+            "spec": """
                 module Trivial {
                     /* @optional dontusethisfieldorifyoudomakesureitsastring */
                     typedef structure {
                         string dontusethisfieldorifyoudomakesureitsastring;
                     } Object;
                 };
-                ''',
-        'dryrun': 0,
-        'new_types': ['Object']
-    })
-    wsc.release_module('Trivial')
+                """,
+            "dryrun": 0,
+            "new_types": ["Object"],
+        }
+    )
+    wsc.release_module("Trivial")
 
 
 @fixture(scope="module")
@@ -393,10 +399,15 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
     # Set up workspace and objects
     wsc = Workspace(ws_controller.get_url(), token=TOKEN_NO_ADMIN)
     wsc.create_workspace({"workspace": "foo"})
-    wsc.save_objects({'id': 1, 'objects': [
-        {'name': 'one', 'type': 'Trivial.Object-1.0', 'data': {}},
-        {'name': 'two', 'type': 'Trivial.Object-1.0', 'data': {}}
-    ]})
+    wsc.save_objects(
+        {
+            "id": 1,
+            "objects": [
+                {"name": "one", "type": "Trivial.Object-1.0", "data": {}},
+                {"name": "two", "type": "Trivial.Object-1.0", "data": {}},
+            ],
+        }
+    )
 
     # need to get the mock objects first so spec_set can do its magic before we mock out
     # the classes in the context manager
@@ -417,12 +428,14 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
 
         # run the method
         ee2 = ee2client(f"http://localhost:{ee2_port}", token=TOKEN_NO_ADMIN)
-        job_id = ee2.run_job({
-            "method": "mod.meth",
-            "app_id": "mod/app",
-            "wsid": 1,
-            "source_ws_objects": ["1/1/1", "1/2/1"]
-        })
+        job_id = ee2.run_job(
+            {
+                "method": "mod.meth",
+                "app_id": "mod/app",
+                "wsid": 1,
+                "source_ws_objects": ["1/1/1", "1/2/1"],
+            }
+        )
 
         # check that mocks were called correctly
         # Since these are class methods, the first argument is self, which we ignore
@@ -444,7 +457,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "+KB_APP_ID": '"mod/app"',
                 "+KB_APP_MODULE_NAME": '"mod"',
                 "+KB_WSID": '"1"',
-                '+KB_SOURCE_WS_OBJECTS': '"1/1/1,1/2/1"',
+                "+KB_SOURCE_WS_OBJECTS": '"1/1/1,1/2/1"',
                 "request_cpus": "4",
                 "request_memory": "2000MB",
                 "request_disk": "30GB",
@@ -485,7 +498,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "method": "mod.meth",
                 "service_ver": "somehash",
                 "app_id": "mod/app",
-                'source_ws_objects': ['1/1/1', '1/2/1'],
+                "source_ws_objects": ["1/1/1", "1/2/1"],
                 "parent_job_id": "None",
                 "requirements": {
                     "clientgroup": "njs",

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -434,6 +434,14 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "app_id": "mod/app",
                 "wsid": 1,
                 "source_ws_objects": ["1/1/1", "1/2/1"],
+                "params": [{"foo": "bar"}, 42],
+                "meta": {"run_id": "rid",
+                         "token_id": "tid",
+                         "tag": "yourit",
+                         "cell_id": "cid",
+                         "status": "totally wasted bro",
+                         "thiskey": "getssilentlydropped",
+                         }
             }
         )
 
@@ -496,6 +504,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
             "job_input": {
                 "wsid": 1,
                 "method": "mod.meth",
+                'params': [{'foo': 'bar'}, 42],
                 "service_ver": "somehash",
                 "app_id": "mod/app",
                 "source_ws_objects": ["1/1/1", "1/2/1"],
@@ -506,7 +515,13 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                     "memory": 2000,
                     "disk": 30,
                 },
-                "narrative_cell_info": {},
+                "narrative_cell_info": {
+                    "run_id": "rid",
+                    "token_id": "tid",
+                    "tag": "yourit",
+                    "cell_id": "cid",
+                    "status": "totally wasted bro",
+                }
             },
             "child_jobs": [],
             "batch_job": False,

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -436,6 +436,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "source_ws_objects": ["1/1/1", "1/2/1"],
                 "params": [{"foo": "bar"}, 42],
                 "service_ver": "beta",
+                "parent_job_id": "totallywrongid",
                 "meta": {"run_id": "rid",
                          "token_id": "tid",
                          "tag": "yourit",
@@ -460,7 +461,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
             {
                 "JobBatchName": job_id,
                 "arguments": f"{job_id} https://ci.kbase.us/services/ee2",
-                "+KB_PARENT_JOB_ID": "",
+                "+KB_PARENT_JOB_ID": '"totallywrongid"',
                 "+KB_MODULE_NAME": '"mod"',
                 "+KB_FUNCTION_NAME": '"meth"',
                 "+KB_APP_ID": '"mod/app"',
@@ -476,9 +477,9 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "+AccountingGroup": f'"{USER_NO_ADMIN}"',
                 "environment": (
                     '"DOCKER_JOB_TIMEOUT=604805 KB_ADMIN_AUTH_TOKEN=test_auth_token '
-                    + f"KB_AUTH_TOKEN={TOKEN_NO_ADMIN} "
-                    + f"CLIENTGROUP=njs JOB_ID={job_id} CONDOR_ID=$(Cluster).$(Process) "
-                    + 'PYTHON_EXECUTABLE=/miniconda/bin/python DEBUG_MODE=False PARENT_JOB_ID= "'
+                    + f"KB_AUTH_TOKEN={TOKEN_NO_ADMIN} CLIENTGROUP=njs JOB_ID={job_id} "
+                    + "CONDOR_ID=$(Cluster).$(Process) PYTHON_EXECUTABLE=/miniconda/bin/python "
+                    + 'DEBUG_MODE=False PARENT_JOB_ID=totallywrongid "'
                 ),
                 "leavejobinqueue": "true",
                 "initial_dir": "../scripts/",
@@ -509,7 +510,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "service_ver": "somehash",
                 "app_id": "mod/app",
                 "source_ws_objects": ["1/1/1", "1/2/1"],
-                "parent_job_id": "None",
+                "parent_job_id": "totallywrongid",
                 "requirements": {
                     "clientgroup": "njs",
                     "cpu": 8,

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -1,7 +1,7 @@
 """
 Integration tests that cover the entire codebase from API to database.
 
-NOTE 1: These tests are designed to only be runnable after running docker-compose up
+NOTE 1: These tests are designed to only be runnable after running docker-compose up.
 
 NOTE 2: These tests were set up quickly in order to debug a problem with administration related
 calls. As such, the auth server was set up to run in test mode locally. If more integrations
@@ -12,7 +12,15 @@ docker containers or exposed to other containers.
 NOTE 3: Although this is supposed to be an integration test, the catalog service and htcondor
 are still mocked out as bringing them up would take a large amount of effort. Someday...
 
-NOTE 4: EE2 posting to Slack always fails silently. Currently slack calls are not tested.
+NOTE 4: Kafka notes
+    a) Currently nothing listens to the kafka feed.
+    b) When running the tests, the kafka producer logs that kafka cannot be reached. However,
+        this error is silent otherwise.
+    c) I wasn't able to contact the docker kafka service with the kafka-python client either.
+    d) As such, Kafka is not tested. Once tests are added, at least one test should check that
+        something sensible happens if a kafka message cannot be sent.
+
+NOTE 5: EE2 posting to Slack always fails silently in tests. Currently slack calls are not tested.
 """
 
 # TODO add more integration tests, these are not necessarily exhaustive
@@ -430,5 +438,3 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
             'scheduler_type': 'condor'
         }
         assert job == expected_job
-
-        # TODO check kafka

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -435,6 +435,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "wsid": 1,
                 "source_ws_objects": ["1/1/1", "1/2/1"],
                 "params": [{"foo": "bar"}, 42],
+                "service_ver": "beta",
                 "meta": {"run_id": "rid",
                          "token_id": "tid",
                          "tag": "yourit",
@@ -448,7 +449,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
         # check that mocks were called correctly
         # Since these are class methods, the first argument is self, which we ignore
         get_mod_ver.assert_called_once_with(
-            ANY, {"module_name": "mod", "version": "release"}
+            ANY, {"module_name": "mod", "version": "beta"}
         )
         list_cgroups.assert_called_once_with(
             ANY, {"module_name": "mod", "function_name": "meth"}

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -57,7 +57,6 @@ from utils_shared.test_utils import (
 from execution_engine2.sdk.EE2Constants import ADMIN_READ_ROLE, ADMIN_WRITE_ROLE
 from installed_clients.baseclient import ServerError
 from installed_clients.execution_engine2Client import execution_engine2 as ee2client
-from installed_clients.CatalogClient import Catalog
 from installed_clients.WorkspaceClient import Workspace
 
 # in the future remove this

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -394,7 +394,7 @@ def _check_htc_calls(sub_init, sub, schedd_init, schedd, txn, expected_sub):
 
 def test_run_job(ee2_port, ws_controller, mongo_client):
     """
-    A simple test of the run_job method.
+    A test of the run_job method.
     """
     # Set up workspace and objects
     wsc = Workspace(ws_controller.get_url(), token=TOKEN_NO_ADMIN)
@@ -423,7 +423,7 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
         # set up the rest of the mocks
         _finish_htc_mocks(sub_init, schedd_init, sub, schedd, txn)
         sub.queue.return_value = 123
-        list_cgroups.return_value = []
+        list_cgroups.return_value = [{"client_groups": ['{"request_cpus":8,"request_memory":5}']}]
         get_mod_ver.return_value = {"git_commit_hash": "somehash"}
 
         # run the method
@@ -466,8 +466,8 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "+KB_APP_MODULE_NAME": '"mod"',
                 "+KB_WSID": '"1"',
                 "+KB_SOURCE_WS_OBJECTS": '"1/1/1,1/2/1"',
-                "request_cpus": "4",
-                "request_memory": "2000MB",
+                "request_cpus": "8",
+                "request_memory": "5MB",
                 "request_disk": "30GB",
                 "requirements": 'regexp("njs",CLIENTGROUP)',
                 "+KB_CLIENTGROUP": '"njs"',
@@ -511,8 +511,8 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
                 "parent_job_id": "None",
                 "requirements": {
                     "clientgroup": "njs",
-                    "cpu": 4,
-                    "memory": 2000,
+                    "cpu": 8,
+                    "memory": 5,
                     "disk": 30,
                 },
                 "narrative_cell_info": {

--- a/test/utils_shared/test_utils.py
+++ b/test/utils_shared/test_utils.py
@@ -402,6 +402,7 @@ def assert_close_to_now(time_):
     assert now_ms + 1 > time_
     assert now_ms - 1 < time_
 
+
 def find_free_port() -> int:
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         s.bind(("", 0))

--- a/test/utils_shared/test_utils.py
+++ b/test/utils_shared/test_utils.py
@@ -3,6 +3,7 @@ import os.path
 import uuid
 import logging
 import socket
+import time
 from configparser import ConfigParser
 from contextlib import closing
 from datetime import datetime
@@ -392,6 +393,14 @@ def assert_exception_correct(got: Exception, expected: Exception):
     assert got.args == expected.args
     assert type(got) == type(expected)
 
+
+def assert_close_to_now(time_):
+    """
+    Checks that a timestamp in seconds since the epoch is within a second of the current time.
+    """
+    now_ms = time.time()
+    assert now_ms + 1 > time_
+    assert now_ms - 1 < time_
 
 def find_free_port() -> int:
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:


### PR DESCRIPTION
# Description of PR purpose/changes

What it says on the tin. Note that the notes at the top of the `api_to_db_test.py` file are pretty important.

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k+ warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
