### PR TITLE
DATAUP-389 - fix a couple of concierge related bugs

### DIFF
--- a/lib/execution_engine2/sdk/EE2Constants.py
+++ b/lib/execution_engine2/sdk/EE2Constants.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 # specify an auth2 role that allows users to replace their token with the kbaseconcierge token
 # when running jobs. Needs more thought.
 KBASE_CONCIERGE_USERNAME = "kbaseconcierge"
-CONCIERGE_CLIENTGROUP = "kbase_concierge"
+CONCIERGE_CLIENTGROUP = "concierge"
 
 EE2_CONFIG_SECTION = "execution_engine2"
 EE2_DEFAULT_SECTION = "DEFAULT"

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -24,6 +24,7 @@ from execution_engine2.sdk.job_submission_parameters import (
     AppInfo,
     UserCreds,
 )
+from execution_engine2.sdk.EE2Constants import CONCIERGE_CLIENTGROUP
 from execution_engine2.utils.job_requirements_resolver import (
     REQUEST_CPUS,
     REQUEST_DISK,
@@ -433,7 +434,7 @@ class EE2RunJob:
             cpus=norm.get(REQUEST_CPUS),
             memory_MB=norm.get(REQUEST_MEMORY),
             disk_GB=norm.get(REQUEST_DISK),
-            client_group=norm.get(CLIENT_GROUP),
+            client_group=norm.get(CLIENT_GROUP) or CONCIERGE_CLIENTGROUP,
             client_group_regex=norm.get(CLIENT_GROUP_REGEX),
             # error messaging here is for 'bill_to_user' vs 'account_group' but almost impossible
             # to screw up so YAGNI

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -362,7 +362,7 @@ def test_run_as_concierge_sched_reqs_empty_list_as_admin():
 def _run_as_concierge_empty_as_admin(concierge_params):
 
     # Set up data variables
-    client_group = "kbase_concierge"  # hardcoded default for run_as_concierge
+    client_group = "concierge"  # hardcoded default for run_as_concierge
     cpus = 1
     mem = 1
     disk = 1

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -362,7 +362,7 @@ def test_run_as_concierge_sched_reqs_empty_list_as_admin():
 def _run_as_concierge_empty_as_admin(concierge_params):
 
     # Set up data variables
-    client_group = "somegroup"
+    client_group = "kbase_concierge"  # hardcoded default for run_as_concierge
     cpus = 1
     mem = 1
     disk = 1
@@ -406,7 +406,7 @@ def _run_as_concierge_empty_as_admin(concierge_params):
         cpus=None,
         memory_MB=None,
         disk_GB=None,
-        client_group=None,
+        client_group=client_group,
         client_group_regex=None,
         ignore_concurrency_limits=True,
         bill_to_user=None,


### PR DESCRIPTION
# Description of PR purpose/changes

* When integrating the job requirements resolver, I missed that when a clientgroup is not provided in the call to `run_job_concierge` a default is provided. The default has been added.
* The default concierge client group in `EE2Constants.py` does not match the name of the client group used in production and in the `deploy.cfg` file, so `s/kbase_concierge/concierge/`.

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [x] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
