### PR TITLE
DATAUP-389 - fix Server.py quoting error messages

### DIFF
--- a/lib/execution_engine2/execution_engine2Server.py
+++ b/lib/execution_engine2/execution_engine2Server.py
@@ -122,7 +122,12 @@ class JSONRPCServiceCustom(JSONRPCService):
             newerr = JSONServerError()
             newerr.trace = traceback.format_exc()
             if len(e.args) == 1:
-                newerr.data = repr(e.args[0])
+                # THIS WAS CHANGED INTENTIONALLY - if you recompile please restore.
+                # repr adds single quotes around string arguments which is not what we want.
+                if type(e.args[0]) == str:
+                    newerr.data = e.args[0]
+                else:
+                    newerr.data = repr(e.args[0])
             else:
                 newerr.data = repr(e.args)
             raise newerr

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -560,17 +560,13 @@ def test_run_job_fail_no_workspace_access(ee2_port):
 
 def test_run_job_fail_bad_method(ee2_port):
     params = {"method": "mod.meth.moke", "app_id": "mod/app"}
-    # TODO the Server.py file is quoting strings for some reason it seems
-    # see https://github.com/kbase/sample_service/blob/master/lib/SampleService/SampleServiceServer.py#L119-L127
-    err = "\"Unrecognized method: 'mod.meth.moke'. Please input module_name.function_name\""
+    err = "Unrecognized method: 'mod.meth.moke'. Please input module_name.function_name"
     _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 
 def test_run_job_fail_bad_app(ee2_port):
     params = {"method": "mod.meth", "app_id": "mod.app"}
-    # TODO the Server.py file is quoting strings for some reason it seems
-    # see https://github.com/kbase/sample_service/blob/master/lib/SampleService/SampleServiceServer.py#L119-L127
-    err = "\"Application ID 'mod.app' contains a '.'\""
+    err = "Application ID 'mod.app' contains a '.'"
     _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 
@@ -580,9 +576,7 @@ def test_run_job_fail_bad_upa(ee2_port):
         "app_id": "mod/app",
         "source_ws_objects": ["ws/obj/1"],
     }
-    # TODO the Server.py file is quoting strings for some reason it seems
-    # see https://github.com/kbase/sample_service/blob/master/lib/SampleService/SampleServiceServer.py#L119-L127
-    err = "\"source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address\""
+    err = "source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address"
     _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 
@@ -599,9 +593,7 @@ def test_run_job_fail_no_such_object(ee2_port, ws_controller):
         }
     )
     params = {"method": "mod.meth", "app_id": "mod/app", "source_ws_objects": ["1/2/1"]}
-    # TODO the Server.py file is quoting strings for some reason it seems
-    # see https://github.com/kbase/sample_service/blob/master/lib/SampleService/SampleServiceServer.py#L119-L127
-    err = "'Some workspace object is inaccessible'"
+    err = "Some workspace object is inaccessible"
     _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -576,7 +576,9 @@ def test_run_job_fail_bad_upa(ee2_port):
         "app_id": "mod/app",
         "source_ws_objects": ["ws/obj/1"],
     }
-    err = "source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address"
+    err = (
+        "source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address"
+    )
     _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 


### PR DESCRIPTION
# Description of PR purpose/changes

At some point someone introduced a bug into the SDK that causes the python server file to unnecessarily quote error strings. This fixes that locally. 
Added an SDK issue for an eventual `fix`: https://github.com/kbase/kb_sdk/issues/363

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
