### PR TITLE
DATAUP-389 - Add happy path integration tests for run_job_concierge

### DIFF
--- a/lib/execution_engine2/utils/Condor.py
+++ b/lib/execution_engine2/utils/Condor.py
@@ -137,8 +137,8 @@ class Condor:
             reqs = [f'regexp("{job_reqs.client_group}",CLIENTGROUP)']
         else:
             reqs = [f'(CLIENTGROUP == "{job_reqs.client_group}")']
-        for key, value in job_reqs.scheduler_requirements.items():
-            reqs.append(f'({key} == "{value}")')
+        for key in sorted(job_reqs.scheduler_requirements):
+            reqs.append(f'({key} == "{job_reqs.scheduler_requirements[key]}")')
         return " && ".join(reqs)
 
     def _add_resources_and_special_attributes(

--- a/test/deploy.cfg
+++ b/test/deploy.cfg
@@ -52,6 +52,11 @@ transfer_input_files = ../scripts/JobRunner.tgz
 debug = false
 
 #---------------------------------------------------------------------------------------#
+[concierge]
+request_cpus = 4
+request_memory = 23000M
+request_disk = 100GB
+#---------------------------------------------------------------------------------------#
 [njs]
 request_cpus = 4
 request_memory = 2000M

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -157,7 +157,9 @@ def _set_up_auth_users(auth_url):
     )
 
     global TOKEN_KBASE_CONCIERGE
-    TOKEN_KBASE_CONCIERGE = _set_up_auth_user(auth_url, USER_KBASE_CONCIERGE, "concierge")
+    TOKEN_KBASE_CONCIERGE = _set_up_auth_user(
+        auth_url, USER_KBASE_CONCIERGE, "concierge"
+    )
 
     global TOKEN_WS_READ_ADMIN
     TOKEN_WS_READ_ADMIN = _set_up_auth_user(
@@ -551,7 +553,9 @@ def test_run_job(ee2_port, ws_controller, mongo_client):
         )
         _check_htc_calls(sub_init, sub, schedd_init, schedd, txn, expected_sub)
 
-        _check_mongo_job(mongo_client, job_id, USER_NO_ADMIN, "njs", 8, 5, 30, "somehash")
+        _check_mongo_job(
+            mongo_client, job_id, USER_NO_ADMIN, "njs", 8, 5, 30, "somehash"
+        )
 
 
 def test_run_job_fail_no_workspace_access(ee2_port):
@@ -632,13 +636,15 @@ def test_run_job_concierge_minimal(ee2_port, ws_controller, mongo_client):
         "concierge",
         4,
         23000,
-        100)
+        100,
+    )
 
 
 def test_run_job_concierge_mixed(ee2_port, ws_controller, mongo_client):
     """
     Gets cpu from the input, memory from deploy.cfg, and disk from the catalog.
     """
+
     def modify_sub(sub):
         del sub["Concurrency_Limits"]
 
@@ -652,36 +658,42 @@ def test_run_job_concierge_mixed(ee2_port, ws_controller, mongo_client):
         76,
         250000,
         7,
-        [{"client_groups": ['{"request_cpus":8,"request_disk":7}']}]
+        [{"client_groups": ['{"request_cpus":8,"request_disk":7}']}],
     )
 
 
 def test_run_job_concierge_maximal(ee2_port, ws_controller, mongo_client):
     def modify_sub(sub):
-        sub["requirements"] = '(CLIENTGROUP == "bigmem") && (baz == "bat") && (foo == "bar")'
+        sub[
+            "requirements"
+        ] = '(CLIENTGROUP == "bigmem") && (baz == "bat") && (foo == "bar")'
         sub["Concurrency_Limits"] = "some_sucker"
         sub["+AccountingGroup"] = '"some_sucker"'
-        sub["environment"] = sub["environment"].replace("DEBUG_MODE=False", "DEBUG_MODE=True")
+        sub["environment"] = sub["environment"].replace(
+            "DEBUG_MODE=False", "DEBUG_MODE=True"
+        )
 
     _run_job_concierge(
         ee2_port,
         ws_controller,
         mongo_client,
-        {"client_group": "bigmem",
-         "request_cpus": 42,
-         "request_memory": 56,
-         "request_disk": 89,
-         "client_group_regex": False,
-         "account_group": "some_sucker",
-         "ignore_concurrency_limits": False,
-         "requirements_list": ['foo=bar', "baz=bat"],
-         "debug_mode": "true",
-         },
+        {
+            "client_group": "bigmem",
+            "request_cpus": 42,
+            "request_memory": 56,
+            "request_disk": 89,
+            "client_group_regex": False,
+            "account_group": "some_sucker",
+            "ignore_concurrency_limits": False,
+            "requirements_list": ["foo=bar", "baz=bat"],
+            "debug_mode": "true",
+        },
         modify_sub,
         "bigmem",
         42,
         56,
-        89)
+        89,
+    )
 
 
 def _run_job_concierge(
@@ -729,11 +741,25 @@ def _run_job_concierge(
         )
 
         expected_sub = _get_condor_sub_for_rj_param_set(
-            job_id, USER_KBASE_CONCIERGE, TOKEN_KBASE_CONCIERGE, clientgroup, cpu, mem, disk
+            job_id,
+            USER_KBASE_CONCIERGE,
+            TOKEN_KBASE_CONCIERGE,
+            clientgroup,
+            cpu,
+            mem,
+            disk,
         )
         modify_sub(expected_sub)
 
         _check_htc_calls(sub_init, sub, schedd_init, schedd, txn, expected_sub)
 
         _check_mongo_job(
-            mongo_client, job_id, USER_KBASE_CONCIERGE, clientgroup, cpu, mem, disk, "somehash")
+            mongo_client,
+            job_id,
+            USER_KBASE_CONCIERGE,
+            clientgroup,
+            cpu,
+            mem,
+            disk,
+            "somehash",
+        )

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -627,16 +627,16 @@ def test_run_job_concierge_minimal(ee2_port, ws_controller, mongo_client):
         del sub["Concurrency_Limits"]
 
     _run_job_concierge(
-        ee2_port,
-        ws_controller,
-        mongo_client,
+        ee2_port=ee2_port,
+        ws_controller=ws_controller,
+        mongo_client=mongo_client,
         # if the concierge dict is empty, regular old run_job gets run
-        {"trigger": "concierge"},  # contents are ignored
-        modify_sub,
-        "concierge",
-        4,
-        23000,
-        100,
+        conc_params={"trigger": "concierge"},  # contents are ignored
+        modify_sub=modify_sub,
+        clientgroup="concierge",
+        cpu=4,
+        mem=23000,
+        disk=100,
     )
 
 
@@ -649,16 +649,16 @@ def test_run_job_concierge_mixed(ee2_port, ws_controller, mongo_client):
         del sub["Concurrency_Limits"]
 
     _run_job_concierge(
-        ee2_port,
-        ws_controller,
-        mongo_client,
-        {"client_group": "extreme", "request_cpus": 76},
-        modify_sub,
-        "extreme",
-        76,
-        250000,
-        7,
-        [{"client_groups": ['{"request_cpus":8,"request_disk":7}']}],
+        ee2_port=ee2_port,
+        ws_controller=ws_controller,
+        mongo_client=mongo_client,
+        conc_params={"client_group": "extreme", "request_cpus": 76},
+        modify_sub=modify_sub,
+        clientgroup="extreme",
+        cpu=76,
+        mem=250000,
+        disk=7,
+        catalog_return=[{"client_groups": ['{"request_cpus":8,"request_disk":7}']}],
     )
 
 
@@ -674,10 +674,10 @@ def test_run_job_concierge_maximal(ee2_port, ws_controller, mongo_client):
         )
 
     _run_job_concierge(
-        ee2_port,
-        ws_controller,
-        mongo_client,
-        {
+        ee2_port=ee2_port,
+        ws_controller=ws_controller,
+        mongo_client=mongo_client,
+        conc_params={
             "client_group": "bigmem",
             "request_cpus": 42,
             "request_memory": 56,
@@ -688,11 +688,11 @@ def test_run_job_concierge_maximal(ee2_port, ws_controller, mongo_client):
             "requirements_list": ["foo=bar", "baz=bat"],
             "debug_mode": "true",
         },
-        modify_sub,
-        "bigmem",
-        42,
-        56,
-        89,
+        modify_sub=modify_sub,
+        clientgroup="bigmem",
+        cpu=42,
+        mem=56,
+        disk=89,
     )
 
 


### PR DESCRIPTION
# Description of PR purpose/changes

What it says on the tin

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
