### PR TITLE
SCT-3026 Upgrade mongo-engine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ maps==5.1.1
 MarkupSafe==1.1.1
 memory-profiler==0.55.0
 mock==3.0.5
-mongoengine==0.18.2
+mongoengine==0.23.0
 multidict==4.5.2
 nose==1.3.7
 packaging==20.4


### PR DESCRIPTION
"The id field is already used to implement the time_span filter, resulting it its usage in a regular field. This prevents the usage of id in a user-provided filter, which is used in a _raw_ filter."