### PR TITLE
DATAUP-389 - Make tests pass when CI is down

### DIFF
--- a/test/tests_for_auth/ee2_admin_mode_test.py
+++ b/test/tests_for_auth/ee2_admin_mode_test.py
@@ -134,7 +134,9 @@ class EE2TestAdminMode(unittest.TestCase):
         aau = clients_and_mocks[AdminAuthUtil]
         catalog = clients_and_mocks[Catalog]
         # TODO check catalog called as expected
-        catalog.get_module_version.return_value = {"git_commit_hash": "moduleversiongoeshere"}
+        catalog.get_module_version.return_value = {
+            "git_commit_hash": "moduleversiongoeshere"
+        }
         catalog.list_client_group_configs.return_value = []
         aau.get_admin_role.return_value = None
         ws_auth.can_write.return_value = True
@@ -225,7 +227,9 @@ class EE2TestAdminMode(unittest.TestCase):
         adminauth = clients_and_mocks[AdminAuthUtil]
         catalog = clients_and_mocks[Catalog]
         # TODO check catalog called as expected
-        catalog.get_module_version.return_value = {"git_commit_hash": "moduleversiongoeshere"}
+        catalog.get_module_version.return_value = {
+            "git_commit_hash": "moduleversiongoeshere"
+        }
         catalog.list_client_group_configs.return_value = []
 
         runner = self.getRunner(None, clients)

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -850,7 +850,9 @@ def test_run_job_concierge_fail_bad_clientgroup(ee2_port):
     err = "No such clientgroup: fakefakefake"
     with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
         list_cgroups.return_value = []
-        _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, conc_params, err)
+        _run_job_concierge_fail(
+            ee2_port, TOKEN_KBASE_CONCIERGE, params, conc_params, err
+        )
 
 
 def test_run_job_concierge_fail_bad_clientgroup_regex(ee2_port):
@@ -901,7 +903,9 @@ def test_run_job_concierge_fail_bad_app(ee2_port):
     err = "Application ID 'mod.app' contains a '.'"
     with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
         list_cgroups.return_value = []
-        _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err)
+        _run_job_concierge_fail(
+            ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err
+        )
 
 
 def test_run_job_concierge_fail_bad_upa(ee2_port):
@@ -910,10 +914,14 @@ def test_run_job_concierge_fail_bad_upa(ee2_port):
         "app_id": _APP,
         "source_ws_objects": ["ws/obj/1"],
     }
-    err = "source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address"
+    err = (
+        "source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address"
+    )
     with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
         list_cgroups.return_value = []
-        _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err)
+        _run_job_concierge_fail(
+            ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err
+        )
 
 
 def test_run_job_concierge_fail_no_such_object(ee2_port, ws_controller):
@@ -932,7 +940,9 @@ def test_run_job_concierge_fail_no_such_object(ee2_port, ws_controller):
     err = "Some workspace object is inaccessible"
     with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
         list_cgroups.return_value = []
-        _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err)
+        _run_job_concierge_fail(
+            ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err
+        )
 
 
 def _run_job_concierge_fail(

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -589,7 +589,9 @@ def test_run_job_fail_bad_method(ee2_port):
 def test_run_job_fail_bad_app(ee2_port):
     params = {"method": _MOD, "app_id": "mod.app"}
     err = "Application ID 'mod.app' contains a '.'"
-    _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 
 def test_run_job_fail_bad_upa(ee2_port):
@@ -601,7 +603,9 @@ def test_run_job_fail_bad_upa(ee2_port):
     err = (
         "source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address"
     )
-    _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 
 def test_run_job_fail_no_such_object(ee2_port, ws_controller):
@@ -618,7 +622,9 @@ def test_run_job_fail_no_such_object(ee2_port, ws_controller):
     )
     params = {"method": _MOD, "app_id": _APP, "source_ws_objects": ["1/2/1"]}
     err = "Some workspace object is inaccessible"
-    _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_fail(ee2_port, TOKEN_NO_ADMIN, params, err)
 
 
 def _run_job_fail(ee2_port, token, params, expected, throw_exception=False):
@@ -842,7 +848,9 @@ def test_run_job_concierge_fail_bad_clientgroup(ee2_port):
     params = {"method": _MOD, "app_id": _APP}
     conc_params = {"client_group": "fakefakefake"}
     err = "No such clientgroup: fakefakefake"
-    _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, conc_params, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, conc_params, err)
 
 
 def test_run_job_concierge_fail_bad_clientgroup_regex(ee2_port):
@@ -891,7 +899,9 @@ def test_run_job_concierge_fail_bad_debug_mode(ee2_port):
 def test_run_job_concierge_fail_bad_app(ee2_port):
     params = {"method": _MOD, "app_id": "mod.app"}
     err = "Application ID 'mod.app' contains a '.'"
-    _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err)
 
 
 def test_run_job_concierge_fail_bad_upa(ee2_port):
@@ -900,10 +910,10 @@ def test_run_job_concierge_fail_bad_upa(ee2_port):
         "app_id": _APP,
         "source_ws_objects": ["ws/obj/1"],
     }
-    err = (
-        "source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address"
-    )
-    _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err)
+    err = "source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address"
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err)
 
 
 def test_run_job_concierge_fail_no_such_object(ee2_port, ws_controller):
@@ -920,7 +930,9 @@ def test_run_job_concierge_fail_no_such_object(ee2_port, ws_controller):
     )
     params = {"method": _MOD, "app_id": _APP, "source_ws_objects": ["1/2/1"]}
     err = "Some workspace object is inaccessible"
-    _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_concierge_fail(ee2_port, TOKEN_KBASE_CONCIERGE, params, {"a": "b"}, err)
 
 
 def _run_job_concierge_fail(
@@ -1198,14 +1210,18 @@ def test_run_job_batch_fail_bad_method(ee2_port, ws_controller):
     err = "Unrecognized method: 'mod.meth.moke'. Please input module_name.function_name"
     # TODO this test surfaced a bug - if a batch wsid is not supplied and any job does not have
     # a wsid an error occurs
-    _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
 
 
 def test_run_job_batch_fail_bad_app(ee2_port, ws_controller):
     _set_up_workspace_objects(ws_controller, TOKEN_NO_ADMIN)
     params = [{"method": _MOD, "app_id": "mod.app"}]
     err = "Application ID 'mod.app' contains a '.'"
-    _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
 
 
 def test_run_job_batch_fail_bad_upa(ee2_port, ws_controller):
@@ -1220,7 +1236,9 @@ def test_run_job_batch_fail_bad_upa(ee2_port, ws_controller):
     err = (
         "source_ws_objects index 0, 'ws/obj/1', is not a valid Unique Permanent Address"
     )
-    _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
 
 
 def test_run_job_batch_fail_parent_id(ee2_port, ws_controller):
@@ -1228,14 +1246,18 @@ def test_run_job_batch_fail_parent_id(ee2_port, ws_controller):
 
     params = [{"method": _MOD, "app_id": _APP, "parent_job_id": "ae"}]
     err = "Batch jobs may not specify a parent job ID"
-    _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
 
     params = [
         {"method": _MOD, "app_id": _APP},
         {"method": _MOD, "app_id": _APP, "parent_job_id": "ae"},
     ]
     err = "Job #2: batch jobs may not specify a parent job ID"
-    _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
 
 
 def test_run_job_batch_fail_no_such_object(ee2_port, ws_controller):
@@ -1252,7 +1274,9 @@ def test_run_job_batch_fail_no_such_object(ee2_port, ws_controller):
     )
     params = [{"method": _MOD, "app_id": _APP, "source_ws_objects": ["1/2/1"]}]
     err = "Some workspace object is inaccessible"
-    _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
+    with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
+        list_cgroups.return_value = []
+        _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)
 
 
 def _run_job_batch_fail(

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
@@ -18,6 +18,8 @@ from execution_engine2.utils.clients import (
     get_user_client_set,
 )
 from execution_engine2.sdk.job_submission_parameters import JobRequirements
+from installed_clients.CatalogClient import Catalog
+
 from test.utils_shared.test_utils import (
     bootstrap,
     get_example_job,
@@ -85,7 +87,8 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         runner = self.getRunner()
         self.assertTrue(set(class_attri) <= set(runner.__dict__.keys()))
 
-    def test_init_job_rec(self):
+    @patch.object(Catalog, "get_module_version")
+    def test_init_job_rec(self, get_mod_ver):
         ori_job_count = Job.objects.count()
         runner = self.getRunner()
 
@@ -111,7 +114,11 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
             "meta": {"tag": "dev", "token_id": "12345"},
         }
 
+        get_mod_ver.return_value = {"git_commit_hash": "048baf3c2b76cb923b3b4c52008ed77dbe20292d"}
+
         job_id = runner.get_runjob()._init_job_rec(self.user_id, job_params)
+
+        get_mod_ver.assert_called_once_with({"module_name": "MEGAHIT", "version": "2.2.1"})
 
         self.assertEqual(ori_job_count, Job.objects.count() - 1)
 

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
@@ -114,11 +114,15 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
             "meta": {"tag": "dev", "token_id": "12345"},
         }
 
-        get_mod_ver.return_value = {"git_commit_hash": "048baf3c2b76cb923b3b4c52008ed77dbe20292d"}
+        get_mod_ver.return_value = {
+            "git_commit_hash": "048baf3c2b76cb923b3b4c52008ed77dbe20292d"
+        }
 
         job_id = runner.get_runjob()._init_job_rec(self.user_id, job_params)
 
-        get_mod_ver.assert_called_once_with({"module_name": "MEGAHIT", "version": "2.2.1"})
+        get_mod_ver.assert_called_once_with(
+            {"module_name": "MEGAHIT", "version": "2.2.1"}
+        )
 
         self.assertEqual(ori_job_count, Job.objects.count() - 1)
 

--- a/test/tests_for_sdkmr/ee2_load_test.py
+++ b/test/tests_for_sdkmr/ee2_load_test.py
@@ -251,12 +251,14 @@ class ee2_server_load_test(unittest.TestCase):
     )
     @patch("installed_clients.CatalogClient.Catalog.get_module_version", autospec=True)
     @patch("installed_clients.CatalogClient.Catalog.log_exec_stats", autospec=True)
-    def test_run_job_stress(self, ccles, ccgmv, cclcgc, workspace, condor):
+    def test_run_job_stress(
+        self, cc_log_stats, cc_get_mod_ver, cc_list_cli_configs, workspace, condor
+    ):
         """
         testing running 3 different jobs in multiple theads.
         """
-        ccgmv.return_value = {"git_commit_hash": "moduleversiongoeshere"}
-        cclcgc.return_value = []
+        cc_get_mod_ver.return_value = {"git_commit_hash": "moduleversiongoeshere"}
+        cc_list_cli_configs.return_value = []
 
         thread_count = self.thread_count  # threads to test
 

--- a/test/tests_for_sdkmr/ee2_load_test.py
+++ b/test/tests_for_sdkmr/ee2_load_test.py
@@ -245,13 +245,15 @@ class ee2_server_load_test(unittest.TestCase):
 
     @patch.object(Condor, "run_job", return_value=si)
     @patch.object(WorkspaceAuth, "can_write", return_value=True)
+    @patch("installed_clients.CatalogClient.Catalog.list_client_group_configs", autospec=True)
     @patch("installed_clients.CatalogClient.Catalog.get_module_version", autospec=True)
     @patch("installed_clients.CatalogClient.Catalog.log_exec_stats", autospec=True)
-    def test_run_job_stress(self, ccles, cc, workspace, condor):
+    def test_run_job_stress(self, ccles, ccgmv, cclcgc, workspace, condor):
         """
         testing running 3 different jobs in multiple theads.
         """
-        cc.return_value = {"git_commit_hash": "moduleversiongoeshere"}
+        ccgmv.return_value = {"git_commit_hash": "moduleversiongoeshere"}
+        cclcgc.return_value = []
 
         thread_count = self.thread_count  # threads to test
 

--- a/test/tests_for_sdkmr/ee2_load_test.py
+++ b/test/tests_for_sdkmr/ee2_load_test.py
@@ -245,7 +245,10 @@ class ee2_server_load_test(unittest.TestCase):
 
     @patch.object(Condor, "run_job", return_value=si)
     @patch.object(WorkspaceAuth, "can_write", return_value=True)
-    @patch("installed_clients.CatalogClient.Catalog.list_client_group_configs", autospec=True)
+    @patch(
+        "installed_clients.CatalogClient.Catalog.list_client_group_configs",
+        autospec=True,
+    )
     @patch("installed_clients.CatalogClient.Catalog.get_module_version", autospec=True)
     @patch("installed_clients.CatalogClient.Catalog.log_exec_stats", autospec=True)
     def test_run_job_stress(self, ccles, ccgmv, cclcgc, workspace, condor):


### PR DESCRIPTION
# Description of PR purpose/changes

What is says on the tin. There's a particular catalog call that accepts any input and returns a reasonable output, so it's easy to miss when mocking.

There's also one test that contacts the external auth service. For now I just added a toggle to manually skip it, but we may want to discuss moving it to the `api_to_db_test` file and using the local auth service started there for the test.

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
