### PR TITLE
DATAUP-389 - specify job requirements in run_job[_batch]

### DIFF
--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -31,13 +31,18 @@ from execution_engine2.utils.job_requirements_resolver import (
     REQUEST_MEMORY,
     CLIENT_GROUP,
     CLIENT_GROUP_REGEX,
+    BILL_TO_USER,
+    IGNORE_CONCURRENCY_LIMITS,
     DEBUG_MODE,
 )
+from execution_engine2.utils.job_requirements_resolver import RequirementsType
 from execution_engine2.utils.KafkaUtils import KafkaCreateJob, KafkaQueueChange
-from execution_engine2.exceptions import IncorrectParamsException
+from execution_engine2.exceptions import IncorrectParamsException, AuthError
 
 
 _JOB_REQUIREMENTS = "job_reqs"
+_JOB_REQUIREMENTS_INCOMING = "job_requirements"
+_SCHEDULER_REQUIREMENTS = "scheduler_requirements"
 _REQUIREMENTS_LIST = "requirements_list"
 _METHOD = "method"
 _APP_ID = "app_id"
@@ -331,7 +336,7 @@ class EE2RunJob:
             wsids = [job_input.get(_WORKSPACE_ID, wsid) for job_input in params]
             self._check_workspace_permissions_list(wsids)
 
-        self._add_job_requirements(params)
+        self._add_job_requirements(params, bool(as_admin))  # as_admin checked above
         self._check_job_arguments(params, has_parent_job=True)
 
         parent_job = self._create_parent_job(wsid=wsid, meta=meta)
@@ -339,20 +344,90 @@ class EE2RunJob:
         return {_PARENT_JOB_ID: str(parent_job.id), "child_job_ids": children_jobs}
 
     # modifies the jobs in place
-    def _add_job_requirements(self, jobs: List[Dict[str, Any]]):
+    def _add_job_requirements(self, jobs: List[Dict[str, Any]], is_write_admin: bool):
         f"""
         Adds the job requirements, generated from the job requirements resolver,
         to the provided RunJobParams dicts. Expects the required field {_METHOD} in the param
-        dicts. Adds the {_JOB_REQUIREMENTS} field to the param dicts, which holds the value of the
-        job requirements object.
+        dicts. Looks in the {_JOB_REQUIREMENTS_INCOMING} key for a dictionary containing the
+        optional keys {REQUEST_CPUS}, {REQUEST_MEMORY}, {REQUEST_DISK}, {CLIENT_GROUP},
+        {CLIENT_GROUP_REGEX}, {BILL_TO_USER}, {IGNORE_CONCURRENCY_LIMITS},
+        {_SCHEDULER_REQUIREMENTS}, and {DEBUG_MODE}. Adds the {_JOB_REQUIREMENTS} field to the
+        param dicts, which holds the value of the job requirements object.
         """
         # could add a cache in the job requirements resolver to avoid making the same
         # catalog call over and over if all the jobs have the same method
         jrr = self.sdkmr.get_job_requirements_resolver()
-        for j in jobs:
-            # TODO JRR check if requesting any job requirements & if is admin
-            # TODO JRR actually process the requirements once added to the spec
-            j[_JOB_REQUIREMENTS] = jrr.resolve_requirements(j.get(_METHOD))
+        for i, job in enumerate(jobs):
+            # TODO I feel like a class for just handling error formatting would be useful
+            # but too much work for a minor benefit
+            pre = f"Job #{i + 1}: " if len(jobs) > 1 else ""
+            job_reqs = job.get(_JOB_REQUIREMENTS_INCOMING) or {}
+            if not isinstance(job_reqs, dict):
+                raise IncorrectParamsException(
+                    f"{pre}{_JOB_REQUIREMENTS_INCOMING} must be a mapping")
+            try:
+                norm = jrr.normalize_job_reqs(job_reqs, "input job")
+            except IncorrectParamsException as e:
+                self._rethrow_incorrect_params_with_error_prefix(e, pre)
+            self._check_job_requirements_vs_admin(jrr, norm, job_reqs, is_write_admin, pre)
+
+            try:
+                job[_JOB_REQUIREMENTS] = jrr.resolve_requirements(
+                    job.get(_METHOD),
+                    cpus=norm.get(REQUEST_CPUS),
+                    memory_MB=norm.get(REQUEST_MEMORY),
+                    disk_GB=norm.get(REQUEST_DISK),
+                    client_group=norm.get(CLIENT_GROUP),
+                    client_group_regex=norm.get(CLIENT_GROUP_REGEX),
+                    bill_to_user=job_reqs.get(BILL_TO_USER),
+                    ignore_concurrency_limits=bool(
+                        job_reqs.get(IGNORE_CONCURRENCY_LIMITS)
+                    ),
+                    scheduler_requirements=job_reqs.get(_SCHEDULER_REQUIREMENTS),
+                    debug_mode=norm.get(DEBUG_MODE),
+                )
+            except IncorrectParamsException as e:
+                self._rethrow_incorrect_params_with_error_prefix(e, pre)
+
+    def _check_job_requirements_vs_admin(self, jrr, norm, job_reqs, is_write_admin, err_prefix):
+        # just a helper method for _add_job_requirements to make that method a bit shorter.
+        # treat it as part of that method
+        try:
+            perm_type = jrr.get_requirements_type(
+                cpus=norm.get(REQUEST_CPUS),
+                memory_MB=norm.get(REQUEST_MEMORY),
+                disk_GB=norm.get(REQUEST_DISK),
+                client_group=norm.get(CLIENT_GROUP),
+                client_group_regex=norm.get(CLIENT_GROUP_REGEX),
+                # Note that this is never confirmed to be a real user. May want to fix that, but
+                # since it's admin only... YAGNI
+                bill_to_user=self._check_is_string(
+                    job_reqs.get(BILL_TO_USER), "bill_to_user"),
+                ignore_concurrency_limits=bool(
+                    job_reqs.get(IGNORE_CONCURRENCY_LIMITS)
+                ),
+                scheduler_requirements=job_reqs.get(_SCHEDULER_REQUIREMENTS),
+                debug_mode=norm.get(DEBUG_MODE)
+            )
+        except IncorrectParamsException as e:
+            self._rethrow_incorrect_params_with_error_prefix(e, err_prefix)
+        if perm_type != RequirementsType.STANDARD and not is_write_admin:
+            raise AuthError(f"{err_prefix}In order to specify job requirements "
+                            + "you must be a full admin")
+
+    def _check_is_string(self, putative_str, name):
+        if not putative_str:
+            return None
+        if type(putative_str) != str:
+            raise IncorrectParamsException(f"{name} must be a string")
+        return putative_str
+
+    def _rethrow_incorrect_params_with_error_prefix(
+        self, error: IncorrectParamsException, error_prefix: str
+    ):
+        if not error_prefix:
+            raise error
+        raise IncorrectParamsException(f"{error_prefix}{error.args[0]}") from error
 
     def _check_job_arguments(self, jobs, has_parent_job=False):
         # perform sanity checks before creating any jobs, including the parent job for batch jobs
@@ -360,18 +435,21 @@ class EE2RunJob:
             # Could make an argument checker method, or a class that doesn't require a job id.
             # Seems like more code & work for no real benefit though.
             # Just create the class for checks, don't use yet
-            JobSubmissionParameters(
-                "fakejobid",
-                AppInfo(job.get(_METHOD), job.get(_APP_ID)),
-                job[_JOB_REQUIREMENTS],
-                UserCreds(self.sdkmr.get_user_id(), self.sdkmr.get_token()),
-                wsid=job.get(_WORKSPACE_ID),
-                source_ws_objects=job.get(_SOURCE_WS_OBJECTS),
-            )
+            pre = f"Job #{i + 1}: " if len(jobs) > 1 else ""
+            try:
+                JobSubmissionParameters(
+                    "fakejobid",
+                    AppInfo(job.get(_METHOD), job.get(_APP_ID)),
+                    job[_JOB_REQUIREMENTS],
+                    UserCreds(self.sdkmr.get_user_id(), self.sdkmr.get_token()),
+                    wsid=job.get(_WORKSPACE_ID),
+                    source_ws_objects=job.get(_SOURCE_WS_OBJECTS),
+                )
+            except IncorrectParamsException as e:
+                self._rethrow_incorrect_params_with_error_prefix(e, pre)
             if has_parent_job and job.get(_PARENT_JOB_ID):
-                pre = f"Job #{i + 1}: b" if len(jobs) > 1 else "B"
                 raise IncorrectParamsException(
-                    f"{pre}atch jobs may not specify a parent job ID"
+                    f"{pre}batch jobs may not specify a parent job ID"
                 )
             # This is also an opportunity for caching
             # although most likely jobs aren't operating on the same object
@@ -399,7 +477,7 @@ class EE2RunJob:
                 params.get(_METHOD), concierge_params
             )
         else:
-            self._add_job_requirements([params])
+            self._add_job_requirements([params], bool(as_admin))  # as_admin checked above
         self._check_job_arguments([params])
 
         return self._run(params=params)
@@ -436,7 +514,7 @@ class EE2RunJob:
             bill_to_user=concierge_params.get("account_group"),
             # default is to ignore concurrency limits for concierge
             ignore_concurrency_limits=bool(
-                concierge_params.get("ignore_concurrency_limits", 1)
+                concierge_params.get(IGNORE_CONCURRENCY_LIMITS, 1)
             ),
             scheduler_requirements=schd_reqs,
             debug_mode=norm.get(DEBUG_MODE),

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -364,12 +364,15 @@ class EE2RunJob:
             job_reqs = job.get(_JOB_REQUIREMENTS_INCOMING) or {}
             if not isinstance(job_reqs, dict):
                 raise IncorrectParamsException(
-                    f"{pre}{_JOB_REQUIREMENTS_INCOMING} must be a mapping")
+                    f"{pre}{_JOB_REQUIREMENTS_INCOMING} must be a mapping"
+                )
             try:
                 norm = jrr.normalize_job_reqs(job_reqs, "input job")
             except IncorrectParamsException as e:
                 self._rethrow_incorrect_params_with_error_prefix(e, pre)
-            self._check_job_requirements_vs_admin(jrr, norm, job_reqs, is_write_admin, pre)
+            self._check_job_requirements_vs_admin(
+                jrr, norm, job_reqs, is_write_admin, pre
+            )
 
             try:
                 job[_JOB_REQUIREMENTS] = jrr.resolve_requirements(
@@ -389,7 +392,9 @@ class EE2RunJob:
             except IncorrectParamsException as e:
                 self._rethrow_incorrect_params_with_error_prefix(e, pre)
 
-    def _check_job_requirements_vs_admin(self, jrr, norm, job_reqs, is_write_admin, err_prefix):
+    def _check_job_requirements_vs_admin(
+        self, jrr, norm, job_reqs, is_write_admin, err_prefix
+    ):
         # just a helper method for _add_job_requirements to make that method a bit shorter.
         # treat it as part of that method
         try:
@@ -402,18 +407,18 @@ class EE2RunJob:
                 # Note that this is never confirmed to be a real user. May want to fix that, but
                 # since it's admin only... YAGNI
                 bill_to_user=self._check_is_string(
-                    job_reqs.get(BILL_TO_USER), "bill_to_user"),
-                ignore_concurrency_limits=bool(
-                    job_reqs.get(IGNORE_CONCURRENCY_LIMITS)
+                    job_reqs.get(BILL_TO_USER), "bill_to_user"
                 ),
+                ignore_concurrency_limits=bool(job_reqs.get(IGNORE_CONCURRENCY_LIMITS)),
                 scheduler_requirements=job_reqs.get(_SCHEDULER_REQUIREMENTS),
-                debug_mode=norm.get(DEBUG_MODE)
+                debug_mode=norm.get(DEBUG_MODE),
             )
         except IncorrectParamsException as e:
             self._rethrow_incorrect_params_with_error_prefix(e, err_prefix)
         if perm_type != RequirementsType.STANDARD and not is_write_admin:
-            raise AuthError(f"{err_prefix}In order to specify job requirements "
-                            + "you must be a full admin")
+            raise AuthError(
+                f"{err_prefix}In order to specify job requirements you must be a full admin"
+            )
 
     def _check_is_string(self, putative_str, name):
         if not putative_str:
@@ -477,7 +482,8 @@ class EE2RunJob:
                 params.get(_METHOD), concierge_params
             )
         else:
-            self._add_job_requirements([params], bool(as_admin))  # as_admin checked above
+            # as_admin checked above
+            self._add_job_requirements([params], bool(as_admin))
         self._check_job_arguments([params])
 
         return self._run(params=params)

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -352,7 +352,7 @@ class EE2RunJob:
         optional keys {REQUEST_CPUS}, {REQUEST_MEMORY}, {REQUEST_DISK}, {CLIENT_GROUP},
         {CLIENT_GROUP_REGEX}, {BILL_TO_USER}, {IGNORE_CONCURRENCY_LIMITS},
         {_SCHEDULER_REQUIREMENTS}, and {DEBUG_MODE}. Adds the {_JOB_REQUIREMENTS} field to the
-        param dicts, which holds the value of the job requirements object.
+        param dicts, which holds the job requirements object.
         """
         # could add a cache in the job requirements resolver to avoid making the same
         # catalog call over and over if all the jobs have the same method

--- a/lib/execution_engine2/utils/job_requirements_resolver.py
+++ b/lib/execution_engine2/utils/job_requirements_resolver.py
@@ -27,10 +27,12 @@ REQUEST_CPUS = "request_cpus"
 REQUEST_MEMORY = "request_memory"
 REQUEST_DISK = "request_disk"
 CLIENT_GROUP_REGEX = "client_group_regex"
+BILL_TO_USER = "bill_to_user"
+IGNORE_CONCURRENCY_LIMITS = "ignore_concurrency_limits"
 DEBUG_MODE = "debug_mode"
 _RESOURCES = set([CLIENT_GROUP, REQUEST_CPUS, REQUEST_MEMORY, REQUEST_DISK])
 _ALL_SPECIAL_KEYS = _RESOURCES | set(
-    [CLIENT_GROUP_REGEX, DEBUG_MODE, "bill_to_user", "ignore_concurrency_limits"]
+    [CLIENT_GROUP_REGEX, DEBUG_MODE, BILL_TO_USER, IGNORE_CONCURRENCY_LIMITS]
 )
 
 _CLIENT_GROUPS = "client_groups"

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -1250,7 +1250,7 @@ def test_run_job_batch_fail_bad_method(ee2_port, ws_controller):
         {"method": _MOD},
         {"method": "mod.meth.moke"},
     ]
-    err = "Unrecognized method: 'mod.meth.moke'. Please input module_name.function_name"
+    err = "Job #2: Unrecognized method: 'mod.meth.moke'. Please input module_name.function_name"
     # TODO this test surfaced a bug - if a batch wsid is not supplied and any job does not have
     # a wsid an error occurs
     with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
@@ -1287,7 +1287,7 @@ def test_run_job_batch_fail_parent_id(ee2_port, ws_controller):
     _set_up_workspace_objects(ws_controller, TOKEN_NO_ADMIN)
 
     params = [{"method": _MOD, "parent_job_id": "ae"}]
-    err = "Batch jobs may not specify a parent job ID"
+    err = "batch jobs may not specify a parent job ID"
     with patch(CAT_LIST_CLIENT_GROUPS, spec_set=True, autospec=True) as list_cgroups:
         list_cgroups.return_value = []
         _run_job_batch_fail(ee2_port, TOKEN_NO_ADMIN, params, {"wsid": 1}, err)

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -347,7 +347,7 @@ def test_run_job_as_admin_with_job_requirements():
             "bill_to_user": _OTHER_USER,
             "scheduler_requirements": {"foo": "bar", "baz": "bat"},
         },
-        internal_representation=True
+        internal_representation=True,
     )
     reqs = ResolvedRequirements(**req_args)
     jrr.resolve_requirements.return_value = reqs
@@ -443,7 +443,7 @@ def test_run_job_as_concierge_with_wsid():
         merge_with={
             "account_group": _OTHER_USER,
             "requirements_list": ["  foo   =   bar   ", "baz=bat"],
-        }
+        },
     )
     assert rj.run(params, concierge_params=conc_params) == _JOB_ID
 
@@ -990,7 +990,9 @@ def test_run_job_batch_as_admin_with_job_requirements():
     # Set up call returns. These calls are in the order they occur in the code
     jrr.normalize_job_reqs.side_effect = [
         {},
-        _create_reqs_dict(cpus, mem, disk, client_group, client_group_regex=True, debug_mode=True),
+        _create_reqs_dict(
+            cpus, mem, disk, client_group, client_group_regex=True, debug_mode=True
+        ),
     ]
     jrr.get_requirements_type.side_effect = [
         RequirementsType.STANDARD,
@@ -1008,7 +1010,7 @@ def test_run_job_batch_as_admin_with_job_requirements():
             "bill_to_user": _OTHER_USER,
             "scheduler_requirements": {"foo": "bar", "baz": "bat"},
         },
-        internal_representation=True
+        internal_representation=True,
     )
     reqs1 = ResolvedRequirements(
         cpus=1, memory_MB=1, disk_GB=1, client_group="verysmallclientgroup"
@@ -1031,7 +1033,7 @@ def test_run_job_batch_as_admin_with_job_requirements():
         merge_with={
             "bill_to_user": _OTHER_USER,
             "scheduler_requirements": {"foo": "bar", "baz": "bat"},
-        }
+        },
     )
     params = [
         {

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -328,12 +328,12 @@ def test_run_job_as_admin_with_job_requirements():
         "bill_to_user": _OTHER_USER,
         "ignore_concurrency_limits": "righty ho, luv",
         "scheduler_requirements": {"foo": "bar", "baz": "bat"},
-        "debug_mode": "true"
+        "debug_mode": "true",
     }
     params = {
         "method": _METHOD,
         "source_ws_objects": [_WS_REF_1, _WS_REF_2],
-        "job_requirements": inc_reqs
+        "job_requirements": inc_reqs,
     }
     assert rj.run(params, as_admin=True) == _JOB_ID
 
@@ -582,9 +582,17 @@ def test_run_job_and_run_job_batch_fail_illegal_arguments():
         IncorrectParamsException("job_requirements must be a mapping"),
     )
     _run_and_run_batch_fail_illegal_arguments(
-        {"method": "foo.bar", "job_requirements": {
-            "bill_to_user": {
-                "Bill": "$3.78", "Boris": "$2.95", "AJ": "$1.32", "Sumin": "$1,469,890.42"}}},
+        {
+            "method": "foo.bar",
+            "job_requirements": {
+                "bill_to_user": {
+                    "Bill": "$3.78",
+                    "Boris": "$2.95",
+                    "AJ": "$1.32",
+                    "Sumin": "$1,469,890.42",
+                }
+            },
+        },
         IncorrectParamsException("bill_to_user must be a string"),
     )
 
@@ -603,7 +611,10 @@ def test_run_job_and_run_job_batch_fail_arg_normalization():
     jrr.normalize_job_reqs.side_effect = IncorrectParamsException(e)
     _run_and_run_batch_fail(
         mocks[SDKMethodRunner],
-        {"method": "foo.bar", "job_requirements": {"request_cpus": "like 10 I guess? IDK"}},
+        {
+            "method": "foo.bar",
+            "job_requirements": {"request_cpus": "like 10 I guess? IDK"},
+        },
         IncorrectParamsException(e),
     )
 
@@ -859,7 +870,10 @@ def test_run_job_batch_with_parent_job_wsid():
     mocks[WorkspaceAuth].can_write_list.return_value = {wsid: True}
 
     jrr.normalize_job_reqs.side_effect = [{}, {}]
-    jrr.get_requirements_type.side_effect = [RequirementsType.STANDARD, RequirementsType.STANDARD]
+    jrr.get_requirements_type.side_effect = [
+        RequirementsType.STANDARD,
+        RequirementsType.STANDARD,
+    ]
     reqs1 = ResolvedRequirements(
         cpus=1,
         memory_MB=2,
@@ -901,9 +915,11 @@ def test_run_job_batch_with_parent_job_wsid():
     mocks[WorkspaceAuth].can_write_list.assert_called_once_with([parent_wsid, wsid])
     jrr = mocks[JobRequirementsResolver]
     jrr.normalize_job_reqs.assert_has_calls(
-        [call({}, "input job"), call({}, "input job")])
-    jrr.get_requirements_type.assert_has_calls([
-        call(**_EMPTY_JOB_REQUIREMENTS), call(**_EMPTY_JOB_REQUIREMENTS)])
+        [call({}, "input job"), call({}, "input job")]
+    )
+    jrr.get_requirements_type.assert_has_calls(
+        [call(**_EMPTY_JOB_REQUIREMENTS), call(**_EMPTY_JOB_REQUIREMENTS)]
+    )
     jrr.resolve_requirements.assert_has_calls(
         [
             call(_METHOD_1, **_EMPTY_JOB_REQUIREMENTS),
@@ -945,10 +961,13 @@ def test_run_job_batch_as_admin_with_job_requirements():
             "request_disk": disk,
             "client_group": client_group,
             "client_group_regex": True,
-            "debug_mode": True
+            "debug_mode": True,
         },
     ]
-    jrr.get_requirements_type.side_effect = [RequirementsType.STANDARD, RequirementsType.BILLING]
+    jrr.get_requirements_type.side_effect = [
+        RequirementsType.STANDARD,
+        RequirementsType.BILLING,
+    ]
     req_args = {
         "cpus": cpus,
         "memory_MB": mem,
@@ -961,7 +980,8 @@ def test_run_job_batch_as_admin_with_job_requirements():
         "debug_mode": True,
     }
     reqs1 = ResolvedRequirements(
-        cpus=1, memory_MB=1, disk_GB=1, client_group="verysmallclientgroup")
+        cpus=1, memory_MB=1, disk_GB=1, client_group="verysmallclientgroup"
+    )
     reqs2 = ResolvedRequirements(**req_args)
     jrr.resolve_requirements.side_effect = [reqs1, reqs2]
 
@@ -978,7 +998,7 @@ def test_run_job_batch_as_admin_with_job_requirements():
         "bill_to_user": _OTHER_USER,
         "ignore_concurrency_limits": "righty ho, luv",
         "scheduler_requirements": {"foo": "bar", "baz": "bat"},
-        "debug_mode": "true"
+        "debug_mode": "true",
     }
     params = [
         {
@@ -1000,12 +1020,15 @@ def test_run_job_batch_as_admin_with_job_requirements():
 
     # check mocks called as expected. The order here is the order that they're called in the code.
     sdkmr.check_as_admin.assert_called_once_with(JobPermissions.WRITE)
-    jrr.normalize_job_reqs.assert_has_calls([
-        call({}, "input job"), call(inc_reqs, "input job")])
-    jrr.get_requirements_type.assert_has_calls([
-        call(**_EMPTY_JOB_REQUIREMENTS), call(**req_args)])
-    jrr.resolve_requirements.assert_has_calls([
-        call(_METHOD_1, **_EMPTY_JOB_REQUIREMENTS), call(_METHOD_2, **req_args)])
+    jrr.normalize_job_reqs.assert_has_calls(
+        [call({}, "input job"), call(inc_reqs, "input job")]
+    )
+    jrr.get_requirements_type.assert_has_calls(
+        [call(**_EMPTY_JOB_REQUIREMENTS), call(**req_args)]
+    )
+    jrr.resolve_requirements.assert_has_calls(
+        [call(_METHOD_1, **_EMPTY_JOB_REQUIREMENTS), call(_METHOD_2, **req_args)]
+    )
     _check_common_mock_calls_batch(mocks, reqs1, reqs2, None, wsid)
 
 
@@ -1031,6 +1054,7 @@ def test_run_batch_fail_params_not_list():
 # Note the next few tests are specifically testing that errors for multiple jobs have the
 # correct job number
 
+
 def test_run_job_batch_fail_illegal_arguments():
     """
     Test that illegal arguments cause the job to fail. Note that not all arguments are
@@ -1048,23 +1072,38 @@ def test_run_job_batch_fail_illegal_arguments():
     job = {"method": "foo.bar"}
 
     _run_batch_fail(
-        rj, [job, job, {}], {}, True, IncorrectParamsException(
-            "Job #3: Missing input parameter: method ID")
+        rj,
+        [job, job, {}],
+        {},
+        True,
+        IncorrectParamsException("Job #3: Missing input parameter: method ID"),
     )
     _run_batch_fail(
-        rj, [job, {"method": "foo.bar", "wsid": 0}], {}, True,
+        rj,
+        [job, {"method": "foo.bar", "wsid": 0}],
+        {},
+        True,
         IncorrectParamsException("Job #2: wsid must be at least 1"),
     )
     _run_batch_fail(
-        rj, [{"method": "foo.bar", "source_ws_objects": {"a": "b"}}, job], {}, True,
+        rj,
+        [{"method": "foo.bar", "source_ws_objects": {"a": "b"}}, job],
+        {},
+        True,
         IncorrectParamsException("Job #1: source_ws_objects must be a list"),
     )
     _run_batch_fail(
-        rj, [job, {"method": "foo.bar", "job_requirements": ["10 bob", "a pickled egg"]}], {}, True,
+        rj,
+        [job, {"method": "foo.bar", "job_requirements": ["10 bob", "a pickled egg"]}],
+        {},
+        True,
         IncorrectParamsException("Job #2: job_requirements must be a mapping"),
     )
     _run_batch_fail(
-        rj, [{"method": "foo.bar", "job_requirements": {"bill_to_user": 1}}, job], {}, True,
+        rj,
+        [{"method": "foo.bar", "job_requirements": {"bill_to_user": 1}}, job],
+        {},
+        True,
         IncorrectParamsException("Job #1: bill_to_user must be a string"),
     )
 
@@ -1076,8 +1115,13 @@ def test_run_job_batch_fail_arg_normalization():
     jrr.normalize_job_reqs.side_effect = [{}, IncorrectParamsException(e)]
     _run_batch_fail(
         EE2RunJob(mocks[SDKMethodRunner]),
-        [{"method": "foo.bar"},
-         {"method": "foo.bar", "job_requirements": {"request_cpus": "like 10 I guess? IDK"}}],
+        [
+            {"method": "foo.bar"},
+            {
+                "method": "foo.bar",
+                "job_requirements": {"request_cpus": "like 10 I guess? IDK"},
+            },
+        ],
         {},
         True,
         IncorrectParamsException("Job #2: " + e),
@@ -1090,13 +1134,17 @@ def test_run_job_batch_fail_get_requirements_type():
     jrr.normalize_job_reqs.return_value = {}
     e = "bill_to_user contains control characters"
     jrr.get_requirements_type.side_effect = [
-        RequirementsType.STANDARD, RequirementsType.STANDARD, IncorrectParamsException(e)]
+        RequirementsType.STANDARD,
+        RequirementsType.STANDARD,
+        IncorrectParamsException(e),
+    ]
     _run_batch_fail(
         EE2RunJob(mocks[SDKMethodRunner]),
-        [{"method": "foo.bar"},
-         {"method": "foo.bar"},
-         {"method": "foo.bar", "job_requirements": {"bill_to_user": "ding\bding"}}
-         ],
+        [
+            {"method": "foo.bar"},
+            {"method": "foo.bar"},
+            {"method": "foo.bar", "job_requirements": {"bill_to_user": "ding\bding"}},
+        ],
         {},
         False,
         IncorrectParamsException("Job #3: " + e),
@@ -1108,15 +1156,20 @@ def test_run_job_batch_fail_not_admin_with_job_reqs():
     jrr = mocks[JobRequirementsResolver]
     jrr.normalize_job_reqs.return_value = {}
     jrr.get_requirements_type.side_effect = [
-        RequirementsType.PROCESSING, RequirementsType.STANDARD]
+        RequirementsType.PROCESSING,
+        RequirementsType.STANDARD,
+    ]
     _run_batch_fail(
         EE2RunJob(mocks[SDKMethodRunner]),
-        [{"method": "foo.bar", "job_requirements": {"ignore_concurrency_limits": 1}},
-         {"method": "foo.bar"}
-         ],
+        [
+            {"method": "foo.bar", "job_requirements": {"ignore_concurrency_limits": 1}},
+            {"method": "foo.bar"},
+        ],
         {},
         False,
-        AuthError("Job #1: In order to specify job requirements you must be a full admin"),
+        AuthError(
+            "Job #1: In order to specify job requirements you must be a full admin"
+        ),
     )
 
 
@@ -1130,12 +1183,11 @@ def test_run_job_batch_fail_resolve_requirements():
     jrr.resolve_requirements.side_effect = [jr, IncorrectParamsException(e)]
     _run_batch_fail(
         EE2RunJob(mocks[SDKMethodRunner]),
-        [{},
-         {"method": "foo.bar"}
-         ],
+        [{}, {"method": "foo.bar"}],
         {},
         False,
-        IncorrectParamsException("Job #2: " + e))
+        IncorrectParamsException("Job #2: " + e),
+    )
 
 
 def test_run_job_batch_fail_parent_id_included():

--- a/test/tests_for_sdkmr/EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/EE2Runjob_test.py
@@ -11,7 +11,7 @@ from logging import Logger
 from unittest.mock import create_autospec, call
 from execution_engine2.authorization.workspaceauth import WorkspaceAuth
 from execution_engine2.db.models.models import Job, JobInput, JobRequirements, Meta
-from execution_engine2.exceptions import IncorrectParamsException
+from execution_engine2.exceptions import IncorrectParamsException, AuthError
 from execution_engine2.sdk.EE2Runjob import EE2RunJob, JobPermissions
 from execution_engine2.sdk.job_submission_parameters import (
     JobSubmissionParameters,
@@ -26,7 +26,10 @@ from execution_engine2.utils.KafkaUtils import (
     KafkaQueueChange,
     KafkaCreateJob,
 )
-from execution_engine2.utils.job_requirements_resolver import JobRequirementsResolver
+from execution_engine2.utils.job_requirements_resolver import (
+    JobRequirementsResolver,
+    RequirementsType,
+)
 from execution_engine2.utils.SlackUtils import SlackClient
 from execution_engine2.db.MongoUtil import MongoUtil
 from installed_clients.WorkspaceClient import Workspace
@@ -60,6 +63,19 @@ _METHOD_2 = "module2.method2"
 _APP_2 = "module2/app2"
 _CLUSTER_1 = "cluster1"
 _CLUSTER_2 = "cluster2"
+
+
+_EMPTY_JOB_REQUIREMENTS = {
+    "cpus": None,
+    "memory_MB": None,
+    "disk_GB": None,
+    "client_group": None,
+    "client_group_regex": None,
+    "bill_to_user": None,
+    "ignore_concurrency_limits": False,
+    "scheduler_requirements": None,
+    "debug_mode": None,
+}
 
 
 def _set_up_mocks(user: str, token: str) -> Dict[Any, Any]:
@@ -205,9 +221,56 @@ def _check_common_mock_calls(mocks, reqs, wsid, app=_APP):
     mocks[SlackClient].run_job_message.assert_called_once_with(_JOB_ID, _CLUSTER, _USER)
 
 
-def test_run_as_admin():
+def test_run_job():
     """
-    A basic unit test of the run() method with an administrative user.
+    A basic unit test of the run() method.
+
+    This test is a fairly minimal test of the run() method. It does not exercise all the
+    potential code paths or provide all the possible run inputs, such as job parameters, cell
+    metadata, etc.
+    """
+
+    # Set up data variables
+    client_group = "myfirstclientgroup"
+    cpus = 1
+    mem = 1
+    disk = 1
+
+    # set up mocks
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    sdkmr = mocks[SDKMethodRunner]
+    jrr = mocks[JobRequirementsResolver]
+    # We intentionally do not check the logger methods as there are a lot of them and this is
+    # already a very large test. This may be something to be added later when needed.
+
+    # Set up call returns. These calls are in the order they occur in the code
+    jrr.normalize_job_reqs.return_value = {}
+    jrr.get_requirements_type.return_value = RequirementsType.STANDARD
+    reqs = ResolvedRequirements(
+        cpus=cpus, memory_MB=mem, disk_GB=disk, client_group=client_group
+    )
+    jrr.resolve_requirements.return_value = reqs
+    _set_up_common_return_values(mocks)
+
+    # set up the class to be tested and run the method
+    rj = EE2RunJob(sdkmr)
+    params = {
+        "method": _METHOD,
+        "app_id": _APP,
+        "source_ws_objects": [_WS_REF_1, _WS_REF_2],
+    }
+    assert rj.run(params) == _JOB_ID
+
+    # check mocks called as expected. The order here is the order that they're called in the code.
+    jrr.normalize_job_reqs.assert_called_once_with({}, "input job")
+    jrr.get_requirements_type.assert_called_once_with(**_EMPTY_JOB_REQUIREMENTS)
+    jrr.resolve_requirements.assert_called_once_with(_METHOD, **_EMPTY_JOB_REQUIREMENTS)
+    _check_common_mock_calls(mocks, reqs, None, _APP)
+
+
+def test_run_job_as_admin_with_job_requirements():
+    """
+    A basic unit test of the run() method with an administrative user and job requirements.
 
     This test is a fairly minimal test of the run() method. It does not exercise all the
     potential code paths or provide all the possible run inputs, such as job parameters, cell
@@ -230,27 +293,59 @@ def test_run_as_admin():
     # already a very large test. This may be something to be added later when needed.
 
     # Set up call returns. These calls are in the order they occur in the code
-    reqs = ResolvedRequirements(
-        cpus=cpus, memory_MB=mem, disk_GB=disk, client_group=client_group
-    )
+    jrr.normalize_job_reqs.return_value = {
+        "request_cpus": cpus,
+        "request_memory": mem,
+        "request_disk": disk,
+        "client_group": client_group,
+        "client_group_regex": True,
+        "debug_mode": True,
+    }
+    jrr.get_requirements_type.return_value = RequirementsType.BILLING
+    req_args = {
+        "cpus": cpus,
+        "memory_MB": mem,
+        "disk_GB": disk,
+        "client_group": client_group,
+        "client_group_regex": True,
+        "bill_to_user": _OTHER_USER,
+        "ignore_concurrency_limits": True,
+        "scheduler_requirements": {"foo": "bar", "baz": "bat"},
+        "debug_mode": True,
+    }
+    reqs = ResolvedRequirements(**req_args)
     jrr.resolve_requirements.return_value = reqs
     _set_up_common_return_values(mocks)
 
     # set up the class to be tested and run the method
     rj = EE2RunJob(sdkmr)
+    inc_reqs = {
+        "request_cpus": cpus,
+        "requst_memory": mem,
+        "request_disk": disk,
+        "client_group": client_group,
+        "client_group_regex": 1,
+        "bill_to_user": _OTHER_USER,
+        "ignore_concurrency_limits": "righty ho, luv",
+        "scheduler_requirements": {"foo": "bar", "baz": "bat"},
+        "debug_mode": "true"
+    }
     params = {
         "method": _METHOD,
         "source_ws_objects": [_WS_REF_1, _WS_REF_2],
+        "job_requirements": inc_reqs
     }
     assert rj.run(params, as_admin=True) == _JOB_ID
 
     # check mocks called as expected. The order here is the order that they're called in the code.
     sdkmr.check_as_admin.assert_called_once_with(JobPermissions.WRITE)
-    jrr.resolve_requirements.assert_called_once_with(_METHOD)
+    jrr.normalize_job_reqs.assert_called_once_with(inc_reqs, "input job")
+    jrr.get_requirements_type.assert_called_once_with(**req_args)
+    jrr.resolve_requirements.assert_called_once_with(_METHOD, **req_args)
     _check_common_mock_calls(mocks, reqs, None, None)
 
 
-def test_run_as_concierge_with_wsid():
+def test_run_job_as_concierge_with_wsid():
     """
     A unit test of the run() method with a concierge - but not admin - user.
 
@@ -337,7 +432,7 @@ def test_run_as_concierge_with_wsid():
     _check_common_mock_calls(mocks, reqs, wsid)
 
 
-def test_run_as_concierge_empty_as_admin():
+def test_run_job_as_concierge_empty_as_admin():
     """
     A unit test of the run() method with an effectively empty concierge dict and admin privs.
     The fake key should be ignored but is required to make the concierge params truthy and
@@ -348,7 +443,7 @@ def test_run_as_concierge_empty_as_admin():
     _run_as_concierge_empty_as_admin({"fake": "foo"}, "lolcats")
 
 
-def test_run_as_concierge_sched_reqs_None_as_admin():
+def test_run_job_as_concierge_sched_reqs_None_as_admin():
     """
     A unit test of the run() method with an concierge dict containing None for the scheduler
     requirements and admin privs.
@@ -360,7 +455,7 @@ def test_run_as_concierge_sched_reqs_None_as_admin():
     )
 
 
-def test_run_as_concierge_sched_reqs_empty_list_as_admin():
+def test_run_job_as_concierge_sched_reqs_empty_list_as_admin():
     """
     A unit test of the run() method with an concierge dict containing an empty list for the
     scheduler requirements and admin privs.
@@ -425,7 +520,7 @@ def _run_as_concierge_empty_as_admin(concierge_params, app):
     _check_common_mock_calls(mocks, reqs, None, app)
 
 
-def test_run_fail_concierge_params():
+def test_run_job_concierge_fail_bad_params():
     """
     Test that submitting invalid concierge params causes the job to fail. Note that most
     error checking happens in the mocked out job requirements resolver, so we only check for
@@ -460,7 +555,7 @@ def _run_fail_concierge_params(concierge_params, expected):
     assert_exception_correct(got.value, expected)
 
 
-def test_run_and_run_batch_fail_illegal_arguments():
+def test_run_job_and_run_job_batch_fail_illegal_arguments():
     """
     Test that illegal arguments cause the job to fail. Note that not all arguments are
     checked - this test checks arguments that are checked in the _check_job_arguments()
@@ -482,17 +577,74 @@ def test_run_and_run_batch_fail_illegal_arguments():
         {"method": "foo.bar", "source_ws_objects": {"a": "b"}},
         IncorrectParamsException("source_ws_objects must be a list"),
     )
+    _run_and_run_batch_fail_illegal_arguments(
+        {"method": "foo.bar", "job_requirements": ["10 bob", "a pickled egg"]},
+        IncorrectParamsException("job_requirements must be a mapping"),
+    )
+    _run_and_run_batch_fail_illegal_arguments(
+        {"method": "foo.bar", "job_requirements": {
+            "bill_to_user": {
+                "Bill": "$3.78", "Boris": "$2.95", "AJ": "$1.32", "Sumin": "$1,469,890.42"}}},
+        IncorrectParamsException("bill_to_user must be a string"),
+    )
 
 
 def _run_and_run_batch_fail_illegal_arguments(params, expected):
     mocks = _set_up_mocks(_USER, _TOKEN)
-    sdkmr = mocks[SDKMethodRunner]
     jrr = mocks[JobRequirementsResolver]
     jrr.resolve_requirements.return_value = ResolvedRequirements(1, 1, 1, "cg")
-    _run_and_run_batch_fail(sdkmr, params, expected)
+    _run_and_run_batch_fail(mocks[SDKMethodRunner], params, expected)
 
 
-def test_run_and_run_batch_fail_workspace_objects_check():
+def test_run_job_and_run_job_batch_fail_arg_normalization():
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    jrr = mocks[JobRequirementsResolver]
+    e = "Found illegal request_cpus 'like 10 I guess? IDK' in job requirements from input job"
+    jrr.normalize_job_reqs.side_effect = IncorrectParamsException(e)
+    _run_and_run_batch_fail(
+        mocks[SDKMethodRunner],
+        {"method": "foo.bar", "job_requirements": {"request_cpus": "like 10 I guess? IDK"}},
+        IncorrectParamsException(e),
+    )
+
+
+def test_run_job_and_run_job_batch_fail_get_requirements_type():
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    jrr = mocks[JobRequirementsResolver]
+    jrr.normalize_job_reqs.return_value = {}
+    e = "bill_to_user contains control characters"
+    jrr.get_requirements_type.side_effect = IncorrectParamsException(e)
+    _run_and_run_batch_fail(
+        mocks[SDKMethodRunner],
+        {"method": "foo.bar", "job_requirements": {"bill_to_user": "ding\bding"}},
+        IncorrectParamsException(e),
+    )
+
+
+def test_run_job_and_run_job_batch_fail_not_admin_with_job_reqs():
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    jrr = mocks[JobRequirementsResolver]
+    jrr.normalize_job_reqs.return_value = {}
+    jrr.get_requirements_type.return_value = RequirementsType.PROCESSING
+    _run_and_run_batch_fail(
+        mocks[SDKMethodRunner],
+        {"method": "foo.bar", "job_requirements": {"ignore_concurrency_limits": 1}},
+        AuthError("In order to specify job requirements you must be a full admin"),
+        as_admin=False,
+    )
+
+
+def test_run_job_and_run_job_batch_fail_resolve_requirements():
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    jrr = mocks[JobRequirementsResolver]
+    jrr.normalize_job_reqs.return_value = {}
+    jrr.get_requirements_type.return_value = RequirementsType.STANDARD
+    e = "Unrecognized method: 'None'. Please input module_name.function_name"
+    jrr.resolve_requirements.side_effect = IncorrectParamsException(e)
+    _run_and_run_batch_fail(mocks[SDKMethodRunner], {}, IncorrectParamsException(e))
+
+
+def test_run_job_and_run_job_batch_fail_workspace_objects_check():
     mocks = _set_up_mocks(_USER, _TOKEN)
     sdkmr = mocks[SDKMethodRunner]
     jrr = mocks[JobRequirementsResolver]
@@ -511,34 +663,19 @@ def test_run_and_run_batch_fail_workspace_objects_check():
     )
 
 
-def _run_and_run_batch_fail(sdkmr, params, expected):
+def _run_and_run_batch_fail(sdkmr, params, expected, as_admin=True):
     rj = EE2RunJob(sdkmr)
     with raises(Exception) as got:
-        rj.run(params, as_admin=True)
+        rj.run(params, as_admin=as_admin)
     assert_exception_correct(got.value, expected)
 
-    with raises(Exception) as got:
-        rj.run_batch([params], {}, as_admin=True)
-    assert_exception_correct(got.value, expected)
+    _run_batch_fail(rj, [params], {}, as_admin, expected)
 
 
 def _set_up_common_return_values_batch(mocks):
     """
     Set up return values on mocks that are the same for several tests.
     """
-    reqs1 = ResolvedRequirements(
-        cpus=1,
-        memory_MB=2,
-        disk_GB=3,
-        client_group="cg1",
-    )
-    reqs2 = ResolvedRequirements(
-        cpus=10,
-        memory_MB=20,
-        disk_GB=30,
-        client_group="cg2",
-    )
-    mocks[JobRequirementsResolver].resolve_requirements.side_effect = [reqs1, reqs2]
     mocks[Workspace].get_object_info3.return_value = {
         "paths": [[_WS_REF_1], [_WS_REF_2]]
     }
@@ -569,7 +706,6 @@ def _set_up_common_return_values_batch(mocks):
     retjob_2.id = ObjectId(_JOB_ID_2)
     retjob_2.status = _CREATED_STATE
     mocks[MongoUtil].get_job.side_effect = [retjob_1, retjob_2]
-    return reqs1, reqs2
 
 
 def _check_common_mock_calls_batch(mocks, reqs1, reqs2, parent_wsid, wsid):
@@ -578,12 +714,6 @@ def _check_common_mock_calls_batch(mocks, reqs1, reqs2, parent_wsid, wsid):
     several tests.
     """
     sdkmr = mocks[SDKMethodRunner]
-    mocks[JobRequirementsResolver].resolve_requirements.assert_has_calls(
-        [
-            call(_METHOD_1),
-            call(_METHOD_2),
-        ]
-    )
     mocks[Workspace].get_object_info3.assert_called_once_with(
         {"objects": [{"ref": _WS_REF_1}, {"ref": _WS_REF_2}], "ignoreErrors": 1}
     )
@@ -705,7 +835,7 @@ def _check_common_mock_calls_batch(mocks, reqs1, reqs2, parent_wsid, wsid):
     assert_jobs_equal(final_got_parent_job, final_expected_parent_job)
 
 
-def test_run_batch_with_parent_job_wsid():
+def test_run_job_batch_with_parent_job_wsid():
     """
     A basic unit test of the run_batch() method, providing a workspace ID for the parent job.
 
@@ -720,14 +850,31 @@ def test_run_batch_with_parent_job_wsid():
     # set up mocks
     mocks = _set_up_mocks(_USER, _TOKEN)
     sdkmr = mocks[SDKMethodRunner]
+    jrr = mocks[JobRequirementsResolver]
     # We intentionally do not check the logger methods as there are a lot of them and this is
     # already a very large test. This may be something to be added later when needed.
 
     # Set up call returns. These calls are in the order they occur in the code
-
     mocks[WorkspaceAuth].can_write.return_value = True
     mocks[WorkspaceAuth].can_write_list.return_value = {wsid: True}
-    reqs1, reqs2 = _set_up_common_return_values_batch(mocks)
+
+    jrr.normalize_job_reqs.side_effect = [{}, {}]
+    jrr.get_requirements_type.side_effect = [RequirementsType.STANDARD, RequirementsType.STANDARD]
+    reqs1 = ResolvedRequirements(
+        cpus=1,
+        memory_MB=2,
+        disk_GB=3,
+        client_group="cg1",
+    )
+    reqs2 = ResolvedRequirements(
+        cpus=10,
+        memory_MB=20,
+        disk_GB=30,
+        client_group="cg2",
+    )
+    jrr.resolve_requirements.side_effect = [reqs1, reqs2]
+
+    _set_up_common_return_values_batch(mocks)
 
     # set up the class to be tested and run the method
     rj = EE2RunJob(sdkmr)
@@ -752,12 +899,24 @@ def test_run_batch_with_parent_job_wsid():
     mocks[WorkspaceAuth].can_write.assert_called_once_with(parent_wsid)
     # this seems like a bug. See comments in the run_batch method
     mocks[WorkspaceAuth].can_write_list.assert_called_once_with([parent_wsid, wsid])
+    jrr = mocks[JobRequirementsResolver]
+    jrr.normalize_job_reqs.assert_has_calls(
+        [call({}, "input job"), call({}, "input job")])
+    jrr.get_requirements_type.assert_has_calls([
+        call(**_EMPTY_JOB_REQUIREMENTS), call(**_EMPTY_JOB_REQUIREMENTS)])
+    jrr.resolve_requirements.assert_has_calls(
+        [
+            call(_METHOD_1, **_EMPTY_JOB_REQUIREMENTS),
+            call(_METHOD_2, **_EMPTY_JOB_REQUIREMENTS),
+        ]
+    )
     _check_common_mock_calls_batch(mocks, reqs1, reqs2, parent_wsid, wsid)
 
 
-def test_run_batch_as_admin():
+def test_run_job_batch_as_admin_with_job_requirements():
     """
-    A basic unit test of the run_batch() method with an administrative user.
+    A basic unit test of the run_batch() method with an administrative user and supplied job
+    requirements.
 
     This test is a fairly minimal test of the run_batch() method. It does not exercise all the
     potential code paths or provide all the possible run inputs, such as job parameters, cell
@@ -765,18 +924,62 @@ def test_run_batch_as_admin():
     """
     # set up variables
     wsid = 32
+    cpus = 89
+    mem = 3
+    disk = 10000
+    client_group = "verylargeclientgroup"
 
     # set up mocks
     mocks = _set_up_mocks(_USER, _TOKEN)
     sdkmr = mocks[SDKMethodRunner]
+    jrr = mocks[JobRequirementsResolver]
     # We intentionally do not check the logger methods as there are a lot of them and this is
     # already a very large test. This may be something to be added later when needed.
 
     # Set up call returns. These calls are in the order they occur in the code
-    reqs1, reqs2 = _set_up_common_return_values_batch(mocks)
+    jrr.normalize_job_reqs.side_effect = [
+        {},
+        {
+            "request_cpus": cpus,
+            "request_memory": mem,
+            "request_disk": disk,
+            "client_group": client_group,
+            "client_group_regex": True,
+            "debug_mode": True
+        },
+    ]
+    jrr.get_requirements_type.side_effect = [RequirementsType.STANDARD, RequirementsType.BILLING]
+    req_args = {
+        "cpus": cpus,
+        "memory_MB": mem,
+        "disk_GB": disk,
+        "client_group": client_group,
+        "client_group_regex": True,
+        "bill_to_user": _OTHER_USER,
+        "ignore_concurrency_limits": True,
+        "scheduler_requirements": {"foo": "bar", "baz": "bat"},
+        "debug_mode": True,
+    }
+    reqs1 = ResolvedRequirements(
+        cpus=1, memory_MB=1, disk_GB=1, client_group="verysmallclientgroup")
+    reqs2 = ResolvedRequirements(**req_args)
+    jrr.resolve_requirements.side_effect = [reqs1, reqs2]
+
+    _set_up_common_return_values_batch(mocks)
 
     # set up the class to be tested and run the method
     rj = EE2RunJob(sdkmr)
+    inc_reqs = {
+        "request_cpus": cpus,
+        "requst_memory": mem,
+        "request_disk": disk,
+        "client_group": client_group,
+        "client_group_regex": 1,
+        "bill_to_user": _OTHER_USER,
+        "ignore_concurrency_limits": "righty ho, luv",
+        "scheduler_requirements": {"foo": "bar", "baz": "bat"},
+        "debug_mode": "true"
+    }
     params = [
         {
             "method": _METHOD_1,
@@ -787,6 +990,7 @@ def test_run_batch_as_admin():
             "method": _METHOD_2,
             "app_id": _APP_2,
             "wsid": wsid,
+            "job_requirements": inc_reqs,
         },
     ]
     assert rj.run_batch(params, {}, as_admin=True) == {
@@ -796,6 +1000,12 @@ def test_run_batch_as_admin():
 
     # check mocks called as expected. The order here is the order that they're called in the code.
     sdkmr.check_as_admin.assert_called_once_with(JobPermissions.WRITE)
+    jrr.normalize_job_reqs.assert_has_calls([
+        call({}, "input job"), call(inc_reqs, "input job")])
+    jrr.get_requirements_type.assert_has_calls([
+        call(**_EMPTY_JOB_REQUIREMENTS), call(**req_args)])
+    jrr.resolve_requirements.assert_has_calls([
+        call(_METHOD_1, **_EMPTY_JOB_REQUIREMENTS), call(_METHOD_2, **req_args)])
     _check_common_mock_calls_batch(mocks, reqs1, reqs2, None, wsid)
 
 
@@ -818,7 +1028,117 @@ def test_run_batch_fail_params_not_list():
         )
 
 
-def test_run_batch_fail_parent_id_included():
+# Note the next few tests are specifically testing that errors for multiple jobs have the
+# correct job number
+
+def test_run_job_batch_fail_illegal_arguments():
+    """
+    Test that illegal arguments cause the job to fail. Note that not all arguments are
+    checked - this test checks arguments that are checked in the _check_job_arguments()
+    method. Furthermore, most argument checking occurs in the job submission parameters
+    class and its respective composed classes, and we don't reproduce all the error conditions
+    possible - just enough to ensure the error checking occurs. If major changes are made to
+    the error checking code then more tests may need to be written.
+
+    """
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    jrr = mocks[JobRequirementsResolver]
+    jrr.resolve_requirements.return_value = ResolvedRequirements(1, 1, 1, "cg")
+    rj = EE2RunJob(mocks[SDKMethodRunner])
+    job = {"method": "foo.bar"}
+
+    _run_batch_fail(
+        rj, [job, job, {}], {}, True, IncorrectParamsException(
+            "Job #3: Missing input parameter: method ID")
+    )
+    _run_batch_fail(
+        rj, [job, {"method": "foo.bar", "wsid": 0}], {}, True,
+        IncorrectParamsException("Job #2: wsid must be at least 1"),
+    )
+    _run_batch_fail(
+        rj, [{"method": "foo.bar", "source_ws_objects": {"a": "b"}}, job], {}, True,
+        IncorrectParamsException("Job #1: source_ws_objects must be a list"),
+    )
+    _run_batch_fail(
+        rj, [job, {"method": "foo.bar", "job_requirements": ["10 bob", "a pickled egg"]}], {}, True,
+        IncorrectParamsException("Job #2: job_requirements must be a mapping"),
+    )
+    _run_batch_fail(
+        rj, [{"method": "foo.bar", "job_requirements": {"bill_to_user": 1}}, job], {}, True,
+        IncorrectParamsException("Job #1: bill_to_user must be a string"),
+    )
+
+
+def test_run_job_batch_fail_arg_normalization():
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    jrr = mocks[JobRequirementsResolver]
+    e = "Found illegal request_cpus 'like 10 I guess? IDK' in job requirements from input job"
+    jrr.normalize_job_reqs.side_effect = [{}, IncorrectParamsException(e)]
+    _run_batch_fail(
+        EE2RunJob(mocks[SDKMethodRunner]),
+        [{"method": "foo.bar"},
+         {"method": "foo.bar", "job_requirements": {"request_cpus": "like 10 I guess? IDK"}}],
+        {},
+        True,
+        IncorrectParamsException("Job #2: " + e),
+    )
+
+
+def test_run_job_batch_fail_get_requirements_type():
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    jrr = mocks[JobRequirementsResolver]
+    jrr.normalize_job_reqs.return_value = {}
+    e = "bill_to_user contains control characters"
+    jrr.get_requirements_type.side_effect = [
+        RequirementsType.STANDARD, RequirementsType.STANDARD, IncorrectParamsException(e)]
+    _run_batch_fail(
+        EE2RunJob(mocks[SDKMethodRunner]),
+        [{"method": "foo.bar"},
+         {"method": "foo.bar"},
+         {"method": "foo.bar", "job_requirements": {"bill_to_user": "ding\bding"}}
+         ],
+        {},
+        False,
+        IncorrectParamsException("Job #3: " + e),
+    )
+
+
+def test_run_job_batch_fail_not_admin_with_job_reqs():
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    jrr = mocks[JobRequirementsResolver]
+    jrr.normalize_job_reqs.return_value = {}
+    jrr.get_requirements_type.side_effect = [
+        RequirementsType.PROCESSING, RequirementsType.STANDARD]
+    _run_batch_fail(
+        EE2RunJob(mocks[SDKMethodRunner]),
+        [{"method": "foo.bar", "job_requirements": {"ignore_concurrency_limits": 1}},
+         {"method": "foo.bar"}
+         ],
+        {},
+        False,
+        AuthError("Job #1: In order to specify job requirements you must be a full admin"),
+    )
+
+
+def test_run_job_batch_fail_resolve_requirements():
+    mocks = _set_up_mocks(_USER, _TOKEN)
+    jrr = mocks[JobRequirementsResolver]
+    jrr.normalize_job_reqs.return_value = {}
+    jrr.get_requirements_type.return_value = RequirementsType.STANDARD
+    e = "Unrecognized method: 'None'. Please input module_name.function_name"
+    jr = ResolvedRequirements(cpus=4, memory_MB=4, disk_GB=4, client_group="cg")
+    jrr.resolve_requirements.side_effect = [jr, IncorrectParamsException(e)]
+    _run_batch_fail(
+        EE2RunJob(mocks[SDKMethodRunner]),
+        [{},
+         {"method": "foo.bar"}
+         ],
+        {},
+        False,
+        IncorrectParamsException("Job #2: " + e))
+
+
+def test_run_job_batch_fail_parent_id_included():
     mocks = _set_up_mocks(_USER, _TOKEN)
     sdkmr = mocks[SDKMethodRunner]
     rj = EE2RunJob(sdkmr)
@@ -828,7 +1148,7 @@ def test_run_batch_fail_parent_id_included():
         [{"method": "foo.bar", "app_id": "foo/bat", "parent_job_id": "a"}],
         {},
         True,
-        IncorrectParamsException("Batch jobs may not specify a parent job ID"),
+        IncorrectParamsException("batch jobs may not specify a parent job ID"),
     )
 
     _run_batch_fail(

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test.py
@@ -22,7 +22,10 @@ from execution_engine2.db.MongoUtil import MongoUtil
 from execution_engine2.utils.Condor import Condor
 from execution_engine2.utils.KafkaUtils import KafkaClient
 from execution_engine2.utils.SlackUtils import SlackClient
-from execution_engine2.utils.job_requirements_resolver import JobRequirementsResolver
+from execution_engine2.utils.job_requirements_resolver import (
+    JobRequirementsResolver,
+    RequirementsType,
+)
 from lib.execution_engine2.db.models.models import Job, Status, TerminatedCode
 from execution_engine2.exceptions import AuthError
 from lib.execution_engine2.exceptions import InvalidStatusTransitionException
@@ -914,6 +917,7 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         )
         runner.workspace_auth = MagicMock()
         runner.get_job_requirements_resolver = MagicMock(return_value=resolver)
+        resolver.get_requirements_type.return_value = RequirementsType.STANDARD
         resolver.resolve_requirements.return_value = JobRequirements(
             cpus=1,
             memory_MB=100,


### PR DESCRIPTION
# Description of PR purpose/changes

What it says on the tin.

Next steps in a future PR:
- in the Impl.py file, pass in an `as_admin` parameter so it's actually possible to specify job requirements at the API level
- add integration tests

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
