### PR TITLE
DATAUP-389 Fix finish_job bug, update for optional app_id in job record

### DIFF
--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -537,8 +537,13 @@ class JobsStatus:
         log_exec_stats_params = dict()
         log_exec_stats_params["user_id"] = job.user
         app_id = job_input.app_id
-        log_exec_stats_params["app_module_name"] = app_id.split("/")[0]
-        log_exec_stats_params["app_id"] = app_id
+        if app_id:
+            # Note this will not work properly for app_ids incorrectly separated by a '.',
+            # which happens in some KBase code (which needs to be fixed at some point) -
+            # notably the narrative data download code, maybe more
+            # It's been this way for a long time, so leave for now
+            log_exec_stats_params["app_module_name"] = app_id.split("/")[0]
+            log_exec_stats_params["app_id"] = app_id
         method = job_input.method
         log_exec_stats_params["func_module_name"] = method.split(".")[0]
         log_exec_stats_params["func_name"] = method.split(".")[-1]


### PR DESCRIPTION
# Description of PR purpose/changes

`finish_job` expected an `app_id` in all job records.

I searched the codebase for `app_id` and I don't see any other places
where it's treated as anything other than an opaque string.

Per the catalog, the app id based fields are optional:
https://github.com/kbase/catalog/blob/master/catalog.spec#L616-L619

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
