### PR TITLE
DATAUP-461 Refactor Retry

### DIFF
--- a/execution_engine2.spec
+++ b/execution_engine2.spec
@@ -459,7 +459,6 @@
         retry_count - int - generated field based on length of retry_ids
         retry_ids - list - list of jobs that are retried based off of this job
         retry_parent - str - job_id of the parent this retry is based off of. Not available on a retry_parent itself
-        retry_saved_toggle - bool - Marked true when all retry steps/txns have completed
 
         parent_job_id - str - job_id taken from job_input.parent_job_id
         batch_job - bool - whether or not this is a batch parent container

--- a/execution_engine2.spec
+++ b/execution_engine2.spec
@@ -428,6 +428,7 @@
         wsid - int - optional id of the workspace where the job is bound
         authstrat - string - what strategy used to authenticate the job
         job_input - object - inputs to the job (from the run_job call)  ## TODO - verify
+        job_output - object - outputs from the job (from the run_job call) ## TODO - verify
         updated - int - timestamp since epoch in milliseconds of the last time the status was updated
         running - int - timestamp since epoch in milliseconds of when it entered the running state
         created - int - timestamp since epoch in milliseconds when the job was created
@@ -452,18 +453,35 @@
         errormsg - string - message (e.g. stacktrace) accompanying an errored job
         error - object - the JSON-RPC error package that accompanies the error code and message
 
-            terminated_code - int - internal reason why a job was terminated, one of:
-                0 - user cancellation
-                1 - admin cancellation
-                2 - terminated by some automatic process
+        #TODO, add these to the structure?
+        condor_job_ads - dict - condor related job information
 
-            @optional error
-            @optional error_code
-            @optional errormsg
-            @optional terminated_code
-            @optional estimating
-            @optional running
-            @optional finished
+        retry_count - int - generated field based on length of retry_ids
+        retry_ids - list - list of jobs that are retried based off of this job
+        retry_parent - str - job_id of the parent this retry is based off of. Not available on a retry_parent itself
+        retry_saved_toggle - bool - Marked true when all retry steps/txns have completed
+
+        parent_job_id - str - job_id taken from job_input.parent_job_id
+        batch_job - bool - whether or not this is a batch parent container
+        child_jobs - array - Only parent container should have child job ids
+
+        scheduler_type - str - scheduler, such as awe or condor
+        scheduler_id - str - scheduler generated id
+        scheduler_estimator_id - str - id for the job spawned for estimation
+
+
+        terminated_code - int - internal reason why a job was terminated, one of:
+            0 - user cancellation
+            1 - admin cancellation
+            2 - terminated by some automatic process
+
+        @optional error
+        @optional error_code
+        @optional errormsg
+        @optional terminated_code
+        @optional estimating
+        @optional running
+        @optional finished
         */
 
 
@@ -484,6 +502,7 @@
             int error_code;
             string errormsg;
             int terminated_code;
+
         } JobState;
 
         /*

--- a/lib/execution_engine2/db/models/models.py
+++ b/lib/execution_engine2/db/models/models.py
@@ -322,12 +322,12 @@ class Job(Document):
     condor_job_ads = DynamicField()
     child_jobs = ListField()  # Only parent container should have child jobs
     # batch_parent_container = BooleanField(default=False) # Only parent container should have this
-
-    # Only present when a job has been retried and on the retry_parent
-    retry_count = IntField(min_value=0)
-
+    retry_ids = ListField()  # The retry_parent has been used to launch these jobs
     # Only present on a retried job, not it's parent. If attempting to retry this job, use its parent instead
     retry_parent = StringField()
+    retry_saved_toggle = BooleanField(
+        default=False
+    )  # Marked true when all retry steps have completed
 
     meta = {"collection": "ee2_jobs"}
 

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -572,7 +572,7 @@ class EE2RunJob:
         # 1) Notify the parent container that it has a new child..
         if parent_job:
             try:
-                parent_job.modify(push__child_jobs=retry_job_id)
+                parent_job.modify(add_to_set__child_jobs=retry_job_id)
             except Exception as e:
                 self._db_update_failure(
                     job_that_failed_operation=str(parent_job.id),
@@ -582,7 +582,7 @@ class EE2RunJob:
 
         # 2) Notify the retry_parent that it has been retried by adding a retry id
         try:
-            job.modify(push__retry_ids=retry_job_id)
+            job.modify(add_to_set__retry_ids=retry_job_id)
         except Exception as e:
             self._db_update_failure(
                 job_that_failed_operation=str(job.id),

--- a/lib/execution_engine2/sdk/EE2Runjob.py
+++ b/lib/execution_engine2/sdk/EE2Runjob.py
@@ -589,10 +589,16 @@ class EE2RunJob:
                 job_to_abort=retry_job_id,
                 exception=e,
             )
-        # If the retry_ids is updated and if present, the child_jobs, is updated, set toggle to true
-        retry_job = self.sdkmr.get_mongo_util().get_job(job_id=retry_job_id)
-        retry_job.retry_saved_toggle = True
-        self.sdkmr.save_job(retry_job)
+        # 3) If the retry_ids is updated and if present, the child_jobs, is updated, set toggle to true
+        try:
+            retry_job = self.sdkmr.get_mongo_util().get_job(job_id=retry_job_id)
+            retry_job.modify(set__retry_saved_toggle=True)
+        except Exception:
+            self.logger.error(
+                f"Couldn't toggle job retry state for {retry_job_id} ",
+                exc_info=True,
+                stack_info=True,
+            )
 
         # Should we compare the original and child job to make sure certain fields match,
         # to make sure the retried job is correctly submitted? Or save that for a unit test?

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -474,6 +474,7 @@ class JobsStatus:
                 del mongo_rec["_id"]
                 mongo_rec["retry_count"] = len(job["retry_ids"])
                 mongo_rec["job_id"] = str(job.id)
+                mongo_rec["parent_job_id"] = job.job_input.parent_job_id
                 mongo_rec["created"] = int(job.id.generation_time.timestamp() * 1000)
                 mongo_rec["updated"] = int(job.updated * 1000)
                 if job.estimating:

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -472,6 +472,7 @@ class JobsStatus:
             else:
                 mongo_rec = job.to_mongo().to_dict()
                 del mongo_rec["_id"]
+                mongo_rec["retry_count"] = len(job["retry_ids"])
                 mongo_rec["job_id"] = str(job.id)
                 mongo_rec["created"] = int(job.id.generation_time.timestamp() * 1000)
                 mongo_rec["updated"] = int(job.updated * 1000)

--- a/lib/execution_engine2/sdk/EE2StatusRange.py
+++ b/lib/execution_engine2/sdk/EE2StatusRange.py
@@ -204,14 +204,13 @@ class JobStatusRange:
         str(job_id)
         float(created/queued/estimating/running/finished/updated/) (Time in MS)
         """
-        retry_keys = ["retry_parent", "retried", "retry_count"]
+        hidden_keys = ["retry_saved_toggle"]
 
         job_states = []
         for job in jobs:
             mongo_rec = job.to_mongo().to_dict()
 
-            # Hack until job browser supports these keys
-            for key in retry_keys:
+            for key in hidden_keys:
                 if key in mongo_rec:
                     del mongo_rec[key]
 

--- a/test/tests_for_db/ee2_MongoUtil_test.py
+++ b/test/tests_for_db/ee2_MongoUtil_test.py
@@ -90,6 +90,8 @@ class MongoUtilTest(unittest.TestCase):
                 "scheduler_id",
                 "child_jobs",
                 "batch_job",
+                "retry_ids",
+                "retry_saved_toggle",
             ]
             self.assertCountEqual(job.keys(), expected_keys)
 
@@ -110,6 +112,8 @@ class MongoUtilTest(unittest.TestCase):
                 "scheduler_id",
                 "batch_job",
                 "child_jobs",
+                "retry_ids",
+                "retry_saved_toggle",
             ]
             self.assertCountEqual(job.keys(), expected_keys)
 
@@ -129,6 +133,8 @@ class MongoUtilTest(unittest.TestCase):
                 "scheduler_id",
                 "batch_job",
                 "child_jobs",
+                "retry_ids",
+                "retry_saved_toggle",
             ]
             self.assertCountEqual(job.keys(), expected_keys)
 
@@ -161,6 +167,8 @@ class MongoUtilTest(unittest.TestCase):
                 "scheduler_id",
                 "batch_job",
                 "child_jobs",
+                "retry_ids",
+                "retry_saved_toggle",
             ]
 
             for job in jobs:
@@ -180,6 +188,8 @@ class MongoUtilTest(unittest.TestCase):
                 "scheduler_id",
                 "batch_job",
                 "child_jobs",
+                "retry_ids",
+                "retry_saved_toggle",
             ]
             for job in jobs:
                 self.assertCountEqual(job.to_mongo().to_dict().keys(), expected_keys)
@@ -211,6 +221,8 @@ class MongoUtilTest(unittest.TestCase):
                 "scheduler_id",
                 "batch_job",
                 "child_jobs",
+                "retry_ids",
+                "retry_saved_toggle",
             ]
 
             self.assertCountEqual(job.keys(), expected_keys)

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -97,6 +97,11 @@ MONGO_EE2_JOBS_COL = "ee2_jobs"
 _MOD = "mod.meth"
 _APP = "mod/app"
 
+# Note (For pycharm, ensure mongo entry is pointing to localhost and uncomment the following)
+from test.utils_shared.test_utils import bootstrap
+
+bootstrap()
+
 
 @fixture(scope="module")
 def config() -> Dict[str, str]:
@@ -528,6 +533,8 @@ def _check_mongo_job(
             },
         },
         "child_jobs": [],
+        "retry_ids": [],
+        "retry_saved_toggle": False,
         "batch_job": False,
         "scheduler_id": "123",
         "scheduler_type": "condor",
@@ -1243,6 +1250,8 @@ def test_run_job_batch(ee2_port, ws_controller, mongo_client):
                 },
             },
             "child_jobs": [],
+            "retry_ids": [],
+            "retry_saved_toggle": False,
             "batch_job": False,
             "scheduler_id": "123",
             "scheduler_type": "condor",
@@ -1272,6 +1281,8 @@ def test_run_job_batch(ee2_port, ws_controller, mongo_client):
                 "narrative_cell_info": {},
             },
             "child_jobs": [],
+            "retry_ids": [],
+            "retry_saved_toggle": False,
             "batch_job": False,
             "scheduler_id": "456",
             "scheduler_type": "condor",
@@ -1299,6 +1310,8 @@ def test_run_job_batch(ee2_port, ws_controller, mongo_client):
             },
             "child_jobs": [job_id_1, job_id_2],
             "batch_job": True,
+            "retry_ids": [],
+            "retry_saved_toggle": False,
         }
         assert parent_job == expected_parent_job
 
@@ -1430,6 +1443,8 @@ def test_run_job_batch_as_admin_with_job_reqs(ee2_port, ws_controller, mongo_cli
             "batch_job": False,
             "scheduler_id": "123",
             "scheduler_type": "condor",
+            "retry_ids": [],
+            "retry_saved_toggle": False,
         }
         assert job1 == expected_job1
 
@@ -1455,6 +1470,8 @@ def test_run_job_batch_as_admin_with_job_reqs(ee2_port, ws_controller, mongo_cli
             "batch_job": False,
             "scheduler_id": "456",
             "scheduler_type": "condor",
+            "retry_ids": [],
+            "retry_saved_toggle": False,
         }
         assert job2 == expected_job2
 
@@ -1474,6 +1491,8 @@ def test_run_job_batch_as_admin_with_job_reqs(ee2_port, ws_controller, mongo_cli
             },
             "child_jobs": [job_id_1, job_id_2],
             "batch_job": True,
+            "retry_ids": [],
+            "retry_saved_toggle": False,
         }
         assert parent_job == expected_parent_job
 

--- a/test/tests_for_integration/api_to_db_test.py
+++ b/test/tests_for_integration/api_to_db_test.py
@@ -28,19 +28,27 @@ NOTE 5: EE2 posting to Slack always fails silently in tests. Currently slack cal
 import os
 import tempfile
 import time
-import htcondor
-
-from bson import ObjectId
 from configparser import ConfigParser
-from threading import Thread
 from pathlib import Path
-import pymongo
-from pytest import fixture, raises
+from threading import Thread
 from typing import Dict
 from unittest.mock import patch, create_autospec, ANY, call
 
+import htcondor
+import pymongo
+from bson import ObjectId
+from pytest import fixture, raises
+
+from execution_engine2.sdk.EE2Constants import ADMIN_READ_ROLE, ADMIN_WRITE_ROLE
+from installed_clients.WorkspaceClient import Workspace
+from installed_clients.baseclient import ServerError
+from installed_clients.execution_engine2Client import execution_engine2 as ee2client
+from test.utils_shared.test_utils import bootstrap
 from tests_for_integration.auth_controller import AuthController
 from tests_for_integration.workspace_controller import WorkspaceController
+
+# in the future remove this
+from tests_for_utils.Condor_test import _get_common_sub
 from utils_shared.test_utils import (
     get_full_test_config,
     get_ee2_test_config,
@@ -54,13 +62,8 @@ from utils_shared.test_utils import (
     assert_close_to_now,
     assert_exception_correct,
 )
-from execution_engine2.sdk.EE2Constants import ADMIN_READ_ROLE, ADMIN_WRITE_ROLE
-from installed_clients.baseclient import ServerError
-from installed_clients.execution_engine2Client import execution_engine2 as ee2client
-from installed_clients.WorkspaceClient import Workspace
 
-# in the future remove this
-from tests_for_utils.Condor_test import _get_common_sub
+bootstrap()
 
 KEEP_TEMP_FILES = False
 TEMP_DIR = Path("test_temp_can_delete")
@@ -96,11 +99,6 @@ MONGO_EE2_JOBS_COL = "ee2_jobs"
 
 _MOD = "mod.meth"
 _APP = "mod/app"
-
-# Note (For pycharm, ensure mongo entry is pointing to localhost and uncomment the following)
-from test.utils_shared.test_utils import bootstrap
-
-bootstrap()
 
 
 @fixture(scope="module")

--- a/test/tests_for_sdkmr/EE2StatusRange_test.py
+++ b/test/tests_for_sdkmr/EE2StatusRange_test.py
@@ -84,6 +84,8 @@ def _run_minimal(user):
                 "status": created_state,
                 "updated": 1000000000,
                 "user": expected_user,
+                "retry_ids": [],
+                "retry_saved_toggle": False,
             }
         ],
         "limit": 2000,

--- a/test/tests_for_sdkmr/EE2StatusRange_test.py
+++ b/test/tests_for_sdkmr/EE2StatusRange_test.py
@@ -85,7 +85,6 @@ def _run_minimal(user):
                 "updated": 1000000000,
                 "user": expected_user,
                 "retry_ids": [],
-                "retry_saved_toggle": False,
             }
         ],
         "limit": 2000,

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
@@ -312,7 +312,7 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
             parent_job_id1,
             parent_job_id2,
         )
-        fail_msg = f"Retry of the same id in the same request is not supported. Offending ids:{[parent_job_id1,parent_job_id2]} "
+        fail_msg = f"Retry of the same id in the same request is not supported. Offending ids:{[parent_job_id1, parent_job_id2]} "
 
         with self.assertRaises(ValueError) as e:
             runner.retry_multiple(retry_candidates)
@@ -419,6 +419,12 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
             else:
                 assert job["retry_parent"] == parent_job_id
                 assert j.retry_saved_toggle
+
+        assert [
+            retried_job["job_id"],
+            retried_job2["job_id"],
+            retried_job3["job_id"],
+        ] == original_job["retry_ids"]
 
         # 4. Get jobs and ensure they contain the same keys and params
         same_keys = ["user", "authstrat", "wsid", "scheduler_type", "job_input"]

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
@@ -7,7 +7,6 @@ from configparser import ConfigParser
 from unittest.mock import patch
 
 import requests_mock
-from bson import ObjectId
 from mock import MagicMock
 
 from execution_engine2.exceptions import CannotRetryJob, RetryFailureException

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Runjob_test.py
@@ -7,6 +7,7 @@ from configparser import ConfigParser
 from unittest.mock import patch
 
 import requests_mock
+from bson import ObjectId
 from mock import MagicMock
 
 from execution_engine2.exceptions import CannotRetryJob, RetryFailureException
@@ -265,7 +266,9 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
                 assert job[item] == retry_job[item]
 
         assert retry_job.retry_parent == job_id
-        assert job.retry_count > 0
+        assert len(job.retry_ids) > 0
+        assert retry_job_id in job.retry_ids
+        assert not job.retry_saved_toggle and retry_job.retry_saved_toggle
 
     @requests_mock.Mocker()
     @patch("lib.execution_engine2.utils.Condor.Condor", autospec=True)
@@ -323,6 +326,9 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
             parent_job_id3,
             parent_job_id4,
         )
+        check_job = runner.check_job(parent_job_id1)
+        assert check_job["retry_ids"] == []
+        assert check_job["retry_count"] == 0
         retry_job_ids = runner.retry_multiple(retry_candidates)
 
         assert len(retry_job_ids) == len(retry_candidates)
@@ -407,10 +413,13 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         self.check_retry_job_state(parent_job_id, retry_from_original_again)
 
         for job in [original_job, retried_job, retried_job2, retried_job3]:
+            j = Job.objects.get(id=job["job_id"])
             if job == original_job:
                 assert original_job["retry_count"] == 3
+                assert not j.retry_saved_toggle
             else:
                 assert job["retry_parent"] == parent_job_id
+                assert j.retry_saved_toggle
 
         # 4. Get jobs and ensure they contain the same keys and params
         same_keys = ["user", "authstrat", "wsid", "scheduler_type", "job_input"]
@@ -529,21 +538,21 @@ class ee2_SDKMethodRunner_test(unittest.TestCase):
         runner.update_job_status(job_id=child_job_id, status=Status.terminated.value)
         parent_job = runner.check_job(job_id=parent_job_id)
         assert len(parent_job["child_jobs"]) == 3
+
         retry_id = runner.retry(job_id=child_job_id)["retry_id"]
+        self.check_retry_job_state(child_job_id, retry_id)
         parent_job = runner.check_job(job_id=parent_job_id)
         assert len(parent_job["child_jobs"]) == 4
         assert parent_job["child_jobs"][-1] == retry_id
 
-        job = Job.objects.get(id=child_job_id)
-        retry_count = job.retry_count
+        job = runner.check_job(job_id=child_job_id)
+        retry_count = job["retry_count"]
 
         # Test to see if one input fails, so fail them all
         with self.assertRaises(expected_exception=RetryFailureException):
-            retry_id = runner.retry_multiple(job_ids=[child_job_id, "grail", "fail"])
-            print(retry_id)
+            runner.retry_multiple(job_ids=[child_job_id, "grail", "fail"])
         # Check to see other job wasn't retried
-        job.reload()
-        assert job.retry_count == retry_count
+        assert retry_count == runner.check_job(job_id=child_job_id)["retry_count"]
 
     @requests_mock.Mocker()
     @patch("lib.execution_engine2.utils.Condor.Condor", autospec=True)

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Status_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Status_test.py
@@ -112,7 +112,6 @@ class ee2_SDKMethodRunner_test_status(unittest.TestCase):
             "queued": 1623781529017,
             "retry_count": 0,
             "retry_ids": [],
-            "retry_saved_toggle": False,
             "scheduler_id": "test",
             "scheduler_type": "condor",
             "status": "queued",

--- a/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Status_test.py
+++ b/test/tests_for_sdkmr/ee2_SDKMethodRunner_test_EE2Status_test.py
@@ -71,6 +71,65 @@ class ee2_SDKMethodRunner_test_status(unittest.TestCase):
 
     @requests_mock.Mocker()
     @patch("lib.execution_engine2.utils.Condor.Condor", autospec=True)
+    def test_check_job(self, rq_mock, condor_mock):
+        rq_mock.add_matcher(
+            run_job_adapter(
+                ws_perms_info={"user_id": self.user_id, "ws_perms": {self.ws_id: "a"}},
+                user_roles=["EE2_ADMIN"],
+            )
+        )
+        runner = self.getRunner()
+        runner.get_condor = MagicMock(return_value=condor_mock)
+        job = get_example_job_as_dict_for_runjob(user=self.user_id, wsid=self.ws_id)
+        si = SubmissionInfo(clusterid="test", submit=job, error=None)
+        condor_mock.run_job = MagicMock(return_value=si)
+        condor_mock.get_job_resource_info = MagicMock(
+            return_value=self.fake_used_resources
+        )
+        job_id = runner.run_job(params=job)
+        job_status = runner.check_job(job_id=job_id)
+        expected_status = {
+            "authstrat": "kbaseworkspace",
+            "batch_job": False,
+            "child_jobs": [],
+            "created": 1623781528000,
+            "job_id": "60c8f0989a70bc8ec0ac0ec7",
+            "job_input": {
+                "app_id": "module/super_function",
+                "method": "module.method",
+                "narrative_cell_info": {},
+                "requirements": {
+                    "clientgroup": "njs",
+                    "cpu": 4,
+                    "disk": 30,
+                    "memory": 2000,
+                },
+                "service_ver": "some_commit_hash",
+                "source_ws_objects": [],
+                "wsid": 9999,
+            },
+            "parent_job_id": None,
+            "queued": 1623781529017,
+            "retry_count": 0,
+            "retry_ids": [],
+            "retry_saved_toggle": False,
+            "scheduler_id": "test",
+            "scheduler_type": "condor",
+            "status": "queued",
+            "updated": 1623781529017,
+            "user": "wsadmin",
+            "wsid": 9999,
+        }
+
+        expected_different = ["job_id", "created", "queued", "updated"]
+        for key, val in expected_status.items():
+            if key not in expected_different:
+                assert job_status[key] == val
+            else:
+                assert key in job_status
+
+    @requests_mock.Mocker()
+    @patch("lib.execution_engine2.utils.Condor.Condor", autospec=True)
     def test_run_job_and_handle_held(self, rq_mock, condor_mock):
         """
         Run a job, then call it held as an admin, and then check to see if the record contains condor info about the job
@@ -99,9 +158,7 @@ class ee2_SDKMethodRunner_test_status(unittest.TestCase):
         print(
             f"Job id is {job_id}. Status is {check_job.get('status')} Cluster is {check_job.get('scheduler_id')} "
         )
-
         job_record = runner.handle_held_job(cluster_id=check_job.get("scheduler_id"))
-        print("Records are", job_record.get("condor_job_ads"))
         self.assertEqual(self.fake_used_resources, job_record.get("condor_job_ads"))
 
     def test_update_job_status(self):

--- a/test/tests_for_sdkmr/ee2_retry_test.py
+++ b/test/tests_for_sdkmr/ee2_retry_test.py
@@ -67,6 +67,8 @@ def test_retry_db_failures():
     rj._db_update_failure = MagicMock()
     rj._retry(job_id=retry_job.id, job=retry_job, parent_job=parent_job)
 
+    assert not retry_job.retry_saved_toggle
+
 
 def test_validate_retry():
     sdkmr = create_autospec(SDKMethodRunner, instance=True, spec_set=True)
@@ -121,6 +123,8 @@ def test_retry_get_run_job_params_from_existing_job():
         "job_input",
         "child_jobs",
         "batch_job",
+        "retry_ids",
+        "retry_saved_toggle",
     ]
     expected_unequal_keys = [
         "updated",


### PR DESCRIPTION
# Description of PR purpose/changes

Summary:
In order to ensure DB consistency, we need to rework the retry mechanism

    Remove retry_count field from record
    Add retry_ids field to record
    Change check_job/check_jobs to return “retry_count” in addition to “retry_ids”
    Change retry to return “retry_ids”
    Add a toggle field to ensure database is consistent in terms of updating the parent_retry and parent_job_id  



# Testing Instructions
* Deployed on CI
* Delete all records with retries in CI db, and prod db.

```
db.getCollection('ee2_jobs').update({'retry_count' : { $exists: true }}, { $set: {"retry_ids": [] }}, {upsert:false,
                          multi:true})  

db.getCollection('ee2_jobs').update({'retry_count' : { $exists: true }}, { $unset: {"retry_count" : ""}}, {upsert:false,
                          multi:true})  

db.getCollection('ee2_jobs').find({'retry_count' : { $exists: true }})
```


# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/data-upload-project/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
