### PR TITLE
Protect the catalog cache internals from external mutation

### DIFF
--- a/lib/execution_engine2/utils/catalog_cache.py
+++ b/lib/execution_engine2/utils/catalog_cache.py
@@ -1,3 +1,5 @@
+import copy
+
 from collections import defaultdict
 from typing import Dict
 
@@ -90,4 +92,4 @@ class CatalogCache:
                 {"module_name": module_name, "function_name": function_name}
             )
         # Retrieve from cache
-        return cr_cache[module_name][function_name]
+        return copy.deepcopy(cr_cache[module_name][function_name])

--- a/test/tests_for_utils/catalog_cache_test.py
+++ b/test/tests_for_utils/catalog_cache_test.py
@@ -107,7 +107,9 @@ def test_cc_job_reqs_internal_mutation(catalog):
     ) == [{"client_groups": ["kb_upload"]}]
 
     # call #2. Regardless of the implementation, this data should be coming from the cache.
-    cgs = cc.lookup_job_resource_requirements("kb_uploadmethods", "import_reads_from_staging")
+    cgs = cc.lookup_job_resource_requirements(
+        "kb_uploadmethods", "import_reads_from_staging"
+    )
     assert cgs == [{"client_groups": ["kb_upload"]}]
 
     # Mutate the cache if the cache implementation allows it
@@ -120,7 +122,10 @@ def test_cc_job_reqs_internal_mutation(catalog):
 
     # check there was only one call to the cache
     catalog.list_client_group_configs.assert_called_once_with(
-        {"module_name": "kb_uploadmethods", "function_name": "import_reads_from_staging"}
+        {
+            "module_name": "kb_uploadmethods",
+            "function_name": "import_reads_from_staging",
+        }
     )
 
 


### PR DESCRIPTION
# Description of PR purpose/changes

The catalog cache exposes the cache internals by reference when returning job requirements, which means that any modification of the returned value modifies the cache. The job requirements resolver does exactly this for CSV formatted client group info from the catalog, popping the client group from the front of the list. This means that for any given app, the first run works normally and any later runs see an empty requirements set if only the clientgroup is specified, or a corrupted requirements set if there are more key/value pairs after the client group.

This PR prevents alteration of the cache by an external client.

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/data-upload-project/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - 3k warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
