### PR TITLE
Added indexes

### DIFF
--- a/lib/execution_engine2/db/models/models.py
+++ b/lib/execution_engine2/db/models/models.py
@@ -336,7 +336,11 @@ class Job(Document):
         default=False
     )  # Marked true when all retry steps have completed
 
-    meta = {"collection": "ee2_jobs"}
+    # See https://docs.mongoengine.org/guide/defining-documents.html#indexes
+    # Hmm, are these indexes need to be + or - ?
+    indexes = [("status", "-created"), ("status", "-queued")]
+
+    meta = {"collection": "ee2_jobs", "indexes": indexes}
 
     def save(self, *args, **kwargs):
         self.updated = time.time()


### PR DESCRIPTION
# Description of PR purpose/changes


 

{"status": Status.queued.value, "queued": {"$lt": before_days}}

{"status": Status.created.value, "created": {"$lt": before_days}}

I don't think there's any indexes on status or the timestamp, so this is going to be a tablescan. I'd recommend making compound indices on state/queued and state/created

I'd just set them up in MongoUtil. That's more or less how I do it for all my servers, for example 
 




https://github.com/kbase/execution_engine2/blob/bc0644a997d6a39a4fbe62e3f7d4f93ec17d22f7/bin/PurgeBadJobs.py#L102

https://github.com/kbase/execution_engine2/blob/bc0644a997d6a39a4fbe62e3f7d4f93ec17d22f7/bin/PurgeBadJobs.py#L81


Hmm I wonder which type of indexes are best, and if I need a different index on 'created' because it actually needs to know if its a batch job or not. 