### PR TITLE
Fix tests on non-UTC systems

### DIFF
--- a/lib/execution_engine2/db/MongoUtil.py
+++ b/lib/execution_engine2/db/MongoUtil.py
@@ -3,7 +3,6 @@ import subprocess
 import time
 import traceback
 from contextlib import contextmanager
-from datetime import datetime, timezone
 from typing import Dict, List
 from bson.objectid import ObjectId
 from mongoengine import connect, connection
@@ -285,7 +284,7 @@ class MongoUtil:
 
         bulk_update_scheduler_jobs = []
         bulk_update_created_to_queued = []
-        queue_time_now = datetime.now(tz=timezone.utc).timestamp()
+        queue_time_now = time.time()
         for job_id_pair in job_id_pairs:
             if job_id_pair.job_id is None:
                 raise ValueError(

--- a/lib/execution_engine2/db/MongoUtil.py
+++ b/lib/execution_engine2/db/MongoUtil.py
@@ -3,7 +3,7 @@ import subprocess
 import time
 import traceback
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List
 from bson.objectid import ObjectId
 from mongoengine import connect, connection
@@ -285,7 +285,7 @@ class MongoUtil:
 
         bulk_update_scheduler_jobs = []
         bulk_update_created_to_queued = []
-        queue_time_now = datetime.utcnow().timestamp()
+        queue_time_now = datetime.now(tz=timezone.utc).timestamp()
         for job_id_pair in job_id_pairs:
             if job_id_pair.job_id is None:
                 raise ValueError(

--- a/test/tests_for_db/ee2_MongoUtil_test.py
+++ b/test/tests_for_db/ee2_MongoUtil_test.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
+import time
 import unittest
-from datetime import datetime, timezone
 
 from bson.objectid import ObjectId
 
@@ -87,8 +87,7 @@ class MongoUtilTest(unittest.TestCase):
             scheduler_ids = ["humpty", "dumpty", "alice"]
             jobs_to_update = list(map(JobIdPair, job_ids, scheduler_ids))
 
-            now_ms = datetime.now(tz=timezone.utc).timestamp()
-
+            now_ms = time.time()
             self.getMongoUtil().update_jobs_to_queued(jobs_to_update)
             job.reload()
             job2.reload()

--- a/test/tests_for_db/ee2_MongoUtil_test.py
+++ b/test/tests_for_db/ee2_MongoUtil_test.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 from bson.objectid import ObjectId
 
@@ -87,7 +87,7 @@ class MongoUtilTest(unittest.TestCase):
             scheduler_ids = ["humpty", "dumpty", "alice"]
             jobs_to_update = list(map(JobIdPair, job_ids, scheduler_ids))
 
-            now_ms = datetime.utcnow().timestamp()
+            now_ms = datetime.now(tz=timezone.utc).timestamp()
 
             self.getMongoUtil().update_jobs_to_queued(jobs_to_update)
             job.reload()


### PR DESCRIPTION
# Description of PR purpose/changes

The tests pass with or without the changes in this commit in the docker
container, which is UTC, but fail without the changes on my laptop, which is
not UTC.

The problem is that `datetime.utcnow()` is not timezone aware, so it
only works on UTC systems.

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite and running tests

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/data-upload-project/development
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
