### PR TITLE
DATAUP-679: Add MongoUtil method to update a single job to queued

### DIFF
--- a/lib/execution_engine2/db/MongoUtil.py
+++ b/lib/execution_engine2/db/MongoUtil.py
@@ -272,7 +272,8 @@ class MongoUtil:
         return False
 
     def update_job_to_queued(
-            self, job_id: str, scheduler_id: str, scheduler_type: str = "condor") -> None:
+        self, job_id: str, scheduler_id: str, scheduler_type: str = "condor"
+    ) -> None:
         f"""
         * Updates a {Status.created.value} job to queued and sets scheduler state.
           Always sets scheduler state, but will only update to queued if the job is in the
@@ -292,13 +293,18 @@ class MongoUtil:
             # should we check that the job was updated and do something if it wasn't?
             ee2_jobs_col.update_one(
                 {"_id": ObjectId(job_id), "status": Status.created.value},
-                {"$set": {"status": Status.queued.value, "queued": queue_time_now}}
+                {"$set": {"status": Status.queued.value, "queued": queue_time_now}},
             )
             # originally had a single query, but seems safer to always record the scheduler
             # state no matter the state of the job
             ee2_jobs_col.update_one(
                 {"_id": ObjectId(job_id)},
-                {"$set": {"scheduler_id": scheduler_id, "scheduler_type": scheduler_type}}
+                {
+                    "$set": {
+                        "scheduler_id": scheduler_id,
+                        "scheduler_type": scheduler_type,
+                    }
+                },
             )
 
     def update_jobs_to_queued(

--- a/lib/execution_engine2/db/MongoUtil.py
+++ b/lib/execution_engine2/db/MongoUtil.py
@@ -271,6 +271,36 @@ class MongoUtil:
             return True
         return False
 
+    def update_job_to_queued(
+            self, job_id: str, scheduler_id: str, scheduler_type: str = "condor") -> None:
+        f"""
+        * Updates a {Status.created.value} job to queued and sets scheduler state.
+          Always sets scheduler state, but will only update to queued if the job is in the
+          {Status.created.value} state.
+        :param job_id: the ID of the job.
+        :param scheduler_id: the scheduler's job ID for the job.
+        :param scheduler_type: The scheduler this job was queued in, default condor
+        """
+        if not job_id or not scheduler_id or not scheduler_type:
+            raise ValueError("None of the 3 arguments can be falsy")
+        # could also test that the job ID is a valid job ID rather than having mongo throw an
+        # error
+        mongo_collection = self.config["mongo-jobs-collection"]
+        queue_time_now = time.time()
+        with self.pymongo_client(mongo_collection) as pymongo_client:
+            ee2_jobs_col = pymongo_client[self.mongo_database][mongo_collection]
+            # should we check that the job was updated and do something if it wasn't?
+            ee2_jobs_col.update_one(
+                {"_id": ObjectId(job_id), "status": Status.created.value},
+                {"$set": {"status": Status.queued.value, "queued": queue_time_now}}
+            )
+            # originally had a single query, but seems safer to always record the scheduler
+            # state no matter the state of the job
+            ee2_jobs_col.update_one(
+                {"_id": ObjectId(job_id)},
+                {"$set": {"scheduler_id": scheduler_id, "scheduler_type": scheduler_type}}
+            )
+
     def update_jobs_to_queued(
         self, job_id_pairs: List[JobIdPair], scheduler_type: str = "condor"
     ) -> None:

--- a/test/tests_for_db/ee2_MongoUtil_test.py
+++ b/test/tests_for_db/ee2_MongoUtil_test.py
@@ -15,7 +15,7 @@ from test.utils_shared.test_utils import (
     get_example_job,
     read_config_into_dict,
     assert_exception_correct,
-    assert_close_to_now
+    assert_close_to_now,
 )
 from tests_for_db.mongo_test_helper import MongoTestHelper
 


### PR DESCRIPTION
# Description of PR purpose/changes

What's on the tin - add a method that updates a single job to the queued state. Next PR will update EE2RunJob to use it instead of the batched method.

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/data-upload-project/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
