### PR TITLE
Don't toggle mongo collection instance variable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # execution_engine2 (ee2) release notes
 =========================================
 
+## 0.0.8
+* Fixed a bug that could, seemingly rarely, cause job and log updates to be applied to the
+  wrong Mongo collection.
+
 ## 0.0.7
 * Fixed a bug that could cause missing `queued` timestamps if many jobs were submitted in a
   batch

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.0.7
+    0.0.8
 
 owners:
     [bsadkhin, tgu2, wjriehl, gaprice]

--- a/lib/execution_engine2/db/MongoUtil.py
+++ b/lib/execution_engine2/db/MongoUtil.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from typing import Dict, List, NamedTuple
 from bson.objectid import ObjectId
 from mongoengine import connect, connection
-from pymongo import MongoClient, UpdateOne
+from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 
 from execution_engine2.db.models.models import JobLog, Job, Status, TerminatedCode

--- a/lib/execution_engine2/execution_engine2Impl.py
+++ b/lib/execution_engine2/execution_engine2Impl.py
@@ -28,7 +28,7 @@ class execution_engine2:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.0.7"
+    VERSION = "0.0.8"
     GIT_URL = "https://github.com/mrcreosote/execution_engine2.git"
     GIT_COMMIT_HASH = "2ad95ce47caa4f1e7b939651f2b1773840e67a8a"
 

--- a/test/tests_for_db/ee2_model_test.py
+++ b/test/tests_for_db/ee2_model_test.py
@@ -42,7 +42,9 @@ class EE2ModelTest(unittest.TestCase):
         logging.info(f"Searching for {job.id}")
         db = self.config["mongo-database"]
         coll = self.config["mongo-jobs-collection"]
-        saved_job = self.mongo_util.pymongoc[db][coll].find_one({"_id": ObjectId(job.id)})
+        saved_job = self.mongo_util.pymongoc[db][coll].find_one(
+            {"_id": ObjectId(job.id)}
+        )
         logging.info("Found")
         logging.info(saved_job)
 

--- a/test/tests_for_db/ee2_model_test.py
+++ b/test/tests_for_db/ee2_model_test.py
@@ -33,28 +33,26 @@ class EE2ModelTest(unittest.TestCase):
 
     def test_insert_job(self):
         logging.info("Testing insert job")
-        with self.mongo_util.mongo_engine_connection(), self.mongo_util.pymongo_client(
-            self.config["mongo-jobs-collection"]
-        ) as pc:
-            job = get_example_job()
-            job.save()
 
-            logging.info(f"Inserted {job.id}")
+        job = get_example_job()
+        job.save()
 
-            logging.info(f"Searching for {job.id}")
-            db = self.config["mongo-database"]
-            coll = self.config["mongo-jobs-collection"]
-            saved_job = pc[db][coll].find_one({"_id": ObjectId(job.id)})
-            logging.info("Found")
-            logging.info(saved_job)
+        logging.info(f"Inserted {job.id}")
 
-            print(job.wsid)
-            print(saved_job["wsid"])
-            self.assertEqual(job.wsid, saved_job["wsid"])
-            self.assertEqual(
-                job.job_input.narrative_cell_info.cell_id,
-                saved_job["job_input"]["narrative_cell_info"]["cell_id"],
-            )
+        logging.info(f"Searching for {job.id}")
+        db = self.config["mongo-database"]
+        coll = self.config["mongo-jobs-collection"]
+        saved_job = self.mongo_util.pymongoc[db][coll].find_one({"_id": ObjectId(job.id)})
+        logging.info("Found")
+        logging.info(saved_job)
+
+        print(job.wsid)
+        print(saved_job["wsid"])
+        self.assertEqual(job.wsid, saved_job["wsid"])
+        self.assertEqual(
+            job.job_input.narrative_cell_info.cell_id,
+            saved_job["job_input"]["narrative_cell_info"]["cell_id"],
+        )
 
     def test_insert_log(self):
         """


### PR DESCRIPTION
# Description of PR purpose/changes

The current MongoUtil implementation has one `mongo_collection` instance
variable that can be set to either the jobs collection or the logs collection
depending on which method was called last. Methods that don't explicitly
choose the collection themselves will use the collection set by whichever
method was most recently called, which might be the wrong collection.

This commit makes two separate variables and ensures the right
collection is being used for each method. It also deletes a number of
unused methods.

# Jira Ticket / Github Issue #
- [n/a] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/data-upload-project/development
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [?] My changes generate no new warnings - lots of warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works - I could technically add a test, but it'd be very weird and wouldn't make a lot of sense IMO
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [x] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
