### PR TITLE
PTV-1832-followup Update catalog call for failed jobs

### DIFF
--- a/.github/workflows/ee2-tests.yml
+++ b/.github/workflows/ee2-tests.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lintentrypoint.sh
+# This workflow will install Python dependencies, run tests and lint
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 # To ssh into this build add the following:

--- a/.github/workflows/ee2-tests.yml
+++ b/.github/workflows/ee2-tests.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint
+# This workflow will install Python dependencies, run tests and lintentrypoint.sh
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 # To ssh into this build add the following:
@@ -23,10 +23,12 @@ jobs:
         with:
           options: "--check --verbose"
           src: "./lib"
+          version: "22.10.0"
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
           src: "./test"
+          version: "22.10.0"
 
   Lint_with_Flake8:
     runs-on: ubuntu-latest

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,22 @@
 # execution_engine2 (ee2) release notes
 =========================================
 
+## 0.0.12
+* Forcing black to 22.1.0 to make sure that GHA doesn't suddenly fail
+* Prevent jobs that never ran from submitting job execution stats
+
+
 ## 0.0.11
-* Add ability to contact condor via token
+* Add ability for `kbase` user to contact condor via token
 
 ## 0.0.10
 * Fixes bug with ee2 not recording all jobs with the catalog during the process 
 of finishing a job
 * Updates GHA with black and flake8
-* Fix flake8 and black formatting issues
+* Fix flake8 and black formatting issues by formatting MANY files
+* Updated docs for installing htcondor
+* Update many python libs in requirements.txt
+
 
 ## 0.0.9
 * Update GHA with latest actions, remove old actions

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -301,7 +301,6 @@ class JobsStatus:
         job = self.sdkmr.get_job_with_permission(
             job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=as_admin
         )
-        job_ran = False if not job.running else True
         if job.status in [
             Status.error.value,
             Status.completed.value,
@@ -370,7 +369,7 @@ class JobsStatus:
             )
 
         # Only send jobs to catalog that actually ran on a worker
-        if job.running is not None:
+        if job.running and job.running >= job.id.generation_time.timestamp():
             self._send_exec_stats_to_catalog(job_id=job_id)
             self._update_finished_job_with_usage(job_id, as_admin=as_admin)
 

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -301,6 +301,7 @@ class JobsStatus:
         job = self.sdkmr.get_job_with_permission(
             job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=as_admin
         )
+        job_ran = False if not job.running else True
         if job.status in [
             Status.error.value,
             Status.completed.value,
@@ -368,8 +369,10 @@ class JobsStatus:
                 )
             )
 
-        self._send_exec_stats_to_catalog(job_id=job_id)
-        self._update_finished_job_with_usage(job_id, as_admin=as_admin)
+        # Only send jobs to catalog that actually ran on a worker
+        if job_ran:
+            self._send_exec_stats_to_catalog(job_id=job_id)
+            self._update_finished_job_with_usage(job_id, as_admin=as_admin)
 
     def _update_finished_job_with_usage(self, job_id, as_admin=None) -> Dict:
         """

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -370,7 +370,7 @@ class JobsStatus:
             )
 
         # Only send jobs to catalog that actually ran on a worker
-        if job_ran:
+        if job.running is not None:
             self._send_exec_stats_to_catalog(job_id=job_id)
             self._update_finished_job_with_usage(job_id, as_admin=as_admin)
 

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -16,15 +16,13 @@ from lib.execution_engine2.utils.Condor import Condor
 from lib.execution_engine2.utils.KafkaUtils import KafkaClient, KafkaFinishJob
 
 
-def _finish_job_complete_minimal_get_test_job(
-    job_id, sched, app_id, gitcommit, user, status=None
-):
+def _finish_job_complete_minimal_get_test_job(job_id, sched, app_id, gitcommit, user):
     job = Job()
     job.id = ObjectId(job_id)
 
-    job.finished = 456.5
-    job.status = Status.running.value if not status else status
-    job.running = 123.0 if job.status is Status.running.value else None
+    job.finished = job.id.generation_time.timestamp() + 10
+    job.status = Status.running.value
+    job.running = job.id.generation_time.timestamp() + 5
     job.scheduler_id = sched
     job_input = JobInput()
     job.job_input = job_input
@@ -120,9 +118,11 @@ def _finish_job_complete_minimal(app_id, app_module):
         "func_module_name": "module",
         "func_name": "method_id",
         "git_commit_hash": gitcommit,
-        "creation_time": 1615246649.0,  # from Job ObjectId
-        "exec_start_time": 123.0,
-        "finish_time": 456.5,
+        "creation_time": ObjectId(
+            job_id
+        ).generation_time.timestamp(),  # from Job ObjectId
+        "exec_start_time": ObjectId(job_id).generation_time.timestamp() + 5,
+        "finish_time": ObjectId(job_id).generation_time.timestamp() + 10,
         "is_error": 0,
         "job_id": job_id,
     }
@@ -132,12 +132,20 @@ def _finish_job_complete_minimal(app_id, app_module):
     catalog.log_exec_stats.assert_called_once_with(les_expected)
     mongo.update_job_resources.assert_called_once_with(job_id, resources)
 
-    # Ensure that catalog stats were not logged for a job that never ran
-    log_exec_stats_call_count = catalog.log_exec_stats.call_count
-    job_id2 = "6046b539ce9c58ecf8c3e5f4"
-    job3 = _finish_job_complete_minimal_get_test_job(
-        job_id2, sched, app_id, gitcommit, user, Status.created.value
-    )
-    sdkmr.get_job_with_permission.side_effect = [job3, job3]
-    JobsStatus(sdkmr).finish_job(job_id2, job_output=job_output)  # no return
-    assert catalog.log_exec_stats.call_count == log_exec_stats_call_count
+    # Ensure that catalog stats were not logged for a job tha was created but failed before running
+    bad_running_timestamps = [-1, 0, None]
+    for timestamp in bad_running_timestamps:
+        log_exec_stats_call_count = catalog.log_exec_stats.call_count
+        job_id2 = "6046b539ce9c58ecf8c3e5f4"
+        subject_job = _finish_job_complete_minimal_get_test_job(
+            job_id2,
+            sched,
+            app_id,
+            gitcommit,
+            user,
+        )
+        subject_job.running = timestamp
+        subject_job.status = Status.created.value
+        sdkmr.get_job_with_permission.side_effect = [subject_job, subject_job]
+        JobsStatus(sdkmr).finish_job(subject_job, job_output=job_output)  # no return
+        assert catalog.log_exec_stats.call_count == log_exec_stats_call_count

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -132,7 +132,7 @@ def _finish_job_complete_minimal(app_id, app_module):
     catalog.log_exec_stats.assert_called_once_with(les_expected)
     mongo.update_job_resources.assert_called_once_with(job_id, resources)
 
-    # Ensure that catalog stats were not logged for a job tha was created but failed before running
+    # Ensure that catalog stats were not logged for a job that was created but failed before running
     bad_running_timestamps = [-1, 0, None]
     for timestamp in bad_running_timestamps:
         log_exec_stats_call_count = catalog.log_exec_stats.call_count

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -136,6 +136,9 @@ def _finish_job_complete_minimal(app_id, app_module):
     bad_running_timestamps = [-1, 0, None]
     for timestamp in bad_running_timestamps:
         log_exec_stats_call_count = catalog.log_exec_stats.call_count
+        update_finished_job_with_usage_call_count = (
+            mongo.update_job_resources.call_count
+        )
         job_id2 = "6046b539ce9c58ecf8c3e5f4"
         subject_job = _finish_job_complete_minimal_get_test_job(
             job_id2,
@@ -149,3 +152,7 @@ def _finish_job_complete_minimal(app_id, app_module):
         sdkmr.get_job_with_permission.side_effect = [subject_job, subject_job]
         JobsStatus(sdkmr).finish_job(subject_job, job_output=job_output)  # no return
         assert catalog.log_exec_stats.call_count == log_exec_stats_call_count
+        assert (
+            mongo.update_job_resources.call_count
+            == update_finished_job_with_usage_call_count
+        )


### PR DESCRIPTION
# Description of PR purpose/changes


* This was covering up the error that my token was expired!!!
* The catalog was throwing an error like so
```
self = <lib.installed_clients.baseclient.BaseClient object at 0x105798e50>
url = 'https://staging.kbase.us/services/ee2'
method = 'execution_engine2.run_job'
params = [{'app_id': 'simpleapp', 'method': 'simpleapp.simple_add', 'params': [{'base_number': '105'}], 'service_ver': 'dev', ...}]
context = None

    def _call(self, url, method, params, context=None):
        arg_hash = {
            "method": method,
            "params": params,
            "version": "1.1",
            "id": str(_random.random())[2:],
        }
        if context:
            if type(context) is not dict:
                raise ValueError("context is not type dict as required.")
            arg_hash["context"] = context
    
        body = _json.dumps(arg_hash, cls=_JSONObjectEncoder)
        ret = _requests.post(
            url,
            data=body,
            headers=self._headers,
            timeout=self.timeout,
            verify=not self.trust_all_ssl_certificates,
        )
        ret.encoding = "utf-8"
        if ret.status_code == 500:
            if ret.headers.get(_CT) == _AJ:
                err = ret.json()
                if "error" in err:
>                   raise ServerError(**err["error"])
E                   lib.installed_clients.baseclient.ServerError: Server error: -32000. "unsupported operand type(s) for -: 'NoneType' and 'float'"
E                   Traceback (most recent call last):
E                     File "/kb/module/lib/execution_engine2/execution_engine2Server.py", line 101, in _call_method
E                       result = method(ctx, *params)
E                     File "/kb/module/lib/execution_engine2/execution_engine2Impl.py", line 262, in run_job
E                       job_id = mr.run_job(params, as_admin=bool(params.get(_AS_ADMIN)))
E                     File "/kb/module/lib/execution_engine2/sdk/SDKMethodRunner.py", line 340, in run_job
E                       return self.get_runjob().run(params=params, as_admin=as_admin)
E                     File "/kb/module/lib/execution_engine2/sdk/EE2Runjob.py", line 942, in run
E                       return self._run(params=params)
E                     File "/kb/module/lib/execution_engine2/sdk/EE2Runjob.py", line 400, in _run
E                       self._finish_created_job(exception=submission_info.error, job_id=job_id)
E                     File "/kb/module/lib/execution_engine2/sdk/EE2Runjob.py", line 229, in _finish_created_job
E                       self.sdkmr.finish_job(
E                     File "/kb/module/lib/execution_engine2/sdk/SDKMethodRunner.py", line 415, in finish_job
E                       return self.get_jobs_status().finish_job(
E                     File "/kb/module/lib/execution_engine2/sdk/EE2Status.py", line 371, in finish_job
E                       self._send_exec_stats_to_catalog(job_id=job_id)
E                     File "/kb/module/lib/execution_engine2/sdk/EE2Status.py", line 565, in _send_exec_stats_to_catalog
E                       self.sdkmr.get_catalog().log_exec_stats(log_exec_stats_params)
E                     File "/kb/module/lib/installed_clients/CatalogClient.py", line 859, in log_exec_stats
E                       return self._client.call_method(
E                     File "/kb/module/lib/installed_clients/baseclient.py", line 311, in call_method
E                       return self._call(url, service_method, args, context)
E                     File "/kb/module/lib/installed_clients/baseclient.py", line 216, in _call
E                       raise ServerError(**err["error"])
E                   installed_clients.baseclient.ServerError: Server error: -32000. "unsupported operand type(s) for -: 'NoneType' and 'float'"
E                   Traceback (most recent call last):
E                     File "/kb/deployment/lib/biokbase/catalog/Server.py", line 101, in _call_method
E                       result = method(ctx, *params)
E                     File "/kb/deployment/lib/biokbase/catalog/Impl.py", line 1115, in log_exec_stats
E                       finish_time, is_error, job_id)
E                     File "/kb/deployment/lib/biokbase/catalog/controller.py", line 1240, in log_exec_stats
E                       finish_time, is_error, "a", "*")
E                     File "/kb/deployment/lib/biokbase/catalog/db.py", line 1124, in add_exec_stats_apps
E                       queue_time = exec_start_time - creation_time
E                   TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'

../../lib/installed_clients/baseclient.py:216: ServerError
```


* Job submission like so

```
@classmethod
    def setUpClass(cls):
        """
        This test is used for sending commands to a live environment, such as CI.
        TravisCI doesn't need to run this test.
        :return:
        """
        next_token = "XXXX"
        os.environ["KB_AUTH_TOKEN"] = next_token
        os.environ["EE2_ENDPOINT"] = "https://XX.kbase.us/services/ee2"
        os.environ["WS_ENDPOINT"] = "https://XX.kbase.us/services/ws"

        if "KB_AUTH_TOKEN" not in os.environ or "EE2_ENDPOINT" not in os.environ:
            logging.error(
                "Make sure you copy the env/test.env.example file to test/env/test.env and populate it"
            )
            sys.exit(1)

        cls.ee2 = execution_engine2(
            url=os.environ["EE2_ENDPOINT"], token=os.environ["KB_AUTH_TOKEN"]
        )
        cls.ws = Workspace(
            url=os.environ["WS_ENDPOINT"], token=os.environ["KB_AUTH_TOKEN"]
        )
```


```
    def test_run_job(self):
        """
        Test a simple job based on runjob params from the spec file

        typedef structure {
            string method;
            list<UnspecifiedObject> params;
            string service_ver;
            RpcContext rpc_context;
            string remote_url;
            list<wsref> source_ws_objects;
            string app_id;
            mapping<string, string> meta;
            int wsid;
            string parent_job_id;
        } RunJobParams;

        :return:
        """
        params = {"base_number": "105"}
        runjob_params = {
            "method": "simpleapp.simple_add",
            "params": [params],
            "service_ver": "dev",
            "wsid": 1200, #your wsid
            "app_id": "simpleapp",
        }

        print("About to submitXXXX")

        job_id = self.ee2.run_job(runjob_params)
        print(f"Submitted job {job_id}")
        job_log_params = {"job_id": job_id}

        # while True:
        #     time.sleep(5)
        #     try:
        #         print(self.ee2.get_job_status(job_log_params))
        #         print(self.ee2.get_job_logs(job_log_params))
        #         status = self.ee2.get_job_status(job_log_params)
        #         if status == {"status": "finished"}:
        #             break
        #     except Exception as e:
        #         print("Not yet", e)
```

# Jira Ticket / Github Issue #
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [x] Changes available by spinning up a local test suite and doing X

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/data-upload-project/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
