### PR TITLE
Devops-960 Remove EE2 AUTOBUILD

### DIFF
--- a/.github/workflows/ee2-tests.yml
+++ b/.github/workflows/ee2-tests.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lintentrypoint.sh
+# This workflow will install Python dependencies, run tests and lint
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 # To ssh into this build add the following:

--- a/.github/workflows/ee2-tests.yml
+++ b/.github/workflows/ee2-tests.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint
+# This workflow will install Python dependencies, run tests and lintentrypoint.sh
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 # To ssh into this build add the following:
@@ -23,10 +23,12 @@ jobs:
         with:
           options: "--check --verbose"
           src: "./lib"
+          version: "22.10.0"
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
           src: "./test"
+          version: "22.10.0"
 
   Lint_with_Flake8:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,11 @@ all: compile build
 compile:
 	kb-sdk compile $(SPEC_FILE) \
 		--out $(LIB_DIR) \
-		--pysrvname $(SERVICE_CAPS).$(SERVICE_CAPS)Server \
-		--pyimplname $(SERVICE_CAPS).$(SERVICE_CAPS)Impl;
+        --pyimplname $(SERVICE_CAPS).$(SERVICE_CAPS)Impl;
+# 		--pysrvname $(SERVICE_CAPS).$(SERVICE_CAPS)Server \
+# Need to comment this out due to bug in kb-sdk, so you should manually build the server and push it into the repo
+# upon changing the specfile
+
 
 	kb-sdk compile $(SPEC_FILE) \
 		--out . \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,22 @@
 # execution_engine2 (ee2) release notes
 =========================================
 
+## 0.0.12
+* Forcing black to 22.1.0 to make sure that GHA doesn't suddenly fail
+* Prevent jobs that never ran from submitting job execution stats
+
+
 ## 0.0.11
-* Add ability to contact condor via token
+* Add ability for `kbase` user to contact condor via token
 
 ## 0.0.10
 * Fixes bug with ee2 not recording all jobs with the catalog during the process 
 of finishing a job
 * Updates GHA with black and flake8
-* Fix flake8 and black formatting issues
+* Fix flake8 and black formatting issues by formatting MANY files
+* Updated docs for installing htcondor
+* Update many python libs in requirements.txt
+
 
 ## 0.0.9
 * Update GHA with latest actions, remove old actions

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -301,7 +301,6 @@ class JobsStatus:
         job = self.sdkmr.get_job_with_permission(
             job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=as_admin
         )
-        job_ran = False if not job.running else True
         if job.status in [
             Status.error.value,
             Status.completed.value,
@@ -370,7 +369,7 @@ class JobsStatus:
             )
 
         # Only send jobs to catalog that actually ran on a worker
-        if job.running is not None:
+        if job.running and job.running >= job.id.generation_time.timestamp():
             self._send_exec_stats_to_catalog(job_id=job_id)
             self._update_finished_job_with_usage(job_id, as_admin=as_admin)
 

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -301,6 +301,7 @@ class JobsStatus:
         job = self.sdkmr.get_job_with_permission(
             job_id=job_id, requested_job_perm=JobPermissions.WRITE, as_admin=as_admin
         )
+        job_ran = False if not job.running else True
         if job.status in [
             Status.error.value,
             Status.completed.value,
@@ -368,8 +369,10 @@ class JobsStatus:
                 )
             )
 
-        self._send_exec_stats_to_catalog(job_id=job_id)
-        self._update_finished_job_with_usage(job_id, as_admin=as_admin)
+        # Only send jobs to catalog that actually ran on a worker
+        if job_ran:
+            self._send_exec_stats_to_catalog(job_id=job_id)
+            self._update_finished_job_with_usage(job_id, as_admin=as_admin)
 
     def _update_finished_job_with_usage(self, job_id, as_admin=None) -> Dict:
         """

--- a/lib/execution_engine2/sdk/EE2Status.py
+++ b/lib/execution_engine2/sdk/EE2Status.py
@@ -370,7 +370,7 @@ class JobsStatus:
             )
 
         # Only send jobs to catalog that actually ran on a worker
-        if job_ran:
+        if job.running is not None:
             self._send_exec_stats_to_catalog(job_id=job_id)
             self._update_finished_job_with_usage(job_id, as_admin=as_admin)
 

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -16,15 +16,13 @@ from lib.execution_engine2.utils.Condor import Condor
 from lib.execution_engine2.utils.KafkaUtils import KafkaClient, KafkaFinishJob
 
 
-def _finish_job_complete_minimal_get_test_job(
-    job_id, sched, app_id, gitcommit, user, status=None
-):
+def _finish_job_complete_minimal_get_test_job(job_id, sched, app_id, gitcommit, user):
     job = Job()
     job.id = ObjectId(job_id)
 
-    job.finished = 456.5
-    job.status = Status.running.value if not status else status
-    job.running = 123.0 if job.status is Status.running.value else None
+    job.finished = job.id.generation_time.timestamp() + 10
+    job.status = Status.running.value
+    job.running = job.id.generation_time.timestamp() + 5
     job.scheduler_id = sched
     job_input = JobInput()
     job.job_input = job_input
@@ -120,9 +118,11 @@ def _finish_job_complete_minimal(app_id, app_module):
         "func_module_name": "module",
         "func_name": "method_id",
         "git_commit_hash": gitcommit,
-        "creation_time": 1615246649.0,  # from Job ObjectId
-        "exec_start_time": 123.0,
-        "finish_time": 456.5,
+        "creation_time": ObjectId(
+            job_id
+        ).generation_time.timestamp(),  # from Job ObjectId
+        "exec_start_time": ObjectId(job_id).generation_time.timestamp() + 5,
+        "finish_time": ObjectId(job_id).generation_time.timestamp() + 10,
         "is_error": 0,
         "job_id": job_id,
     }
@@ -132,12 +132,20 @@ def _finish_job_complete_minimal(app_id, app_module):
     catalog.log_exec_stats.assert_called_once_with(les_expected)
     mongo.update_job_resources.assert_called_once_with(job_id, resources)
 
-    # Ensure that catalog stats were not logged for a job that never ran
-    log_exec_stats_call_count = catalog.log_exec_stats.call_count
-    job_id2 = "6046b539ce9c58ecf8c3e5f4"
-    job3 = _finish_job_complete_minimal_get_test_job(
-        job_id2, sched, app_id, gitcommit, user, Status.created.value
-    )
-    sdkmr.get_job_with_permission.side_effect = [job3, job3]
-    JobsStatus(sdkmr).finish_job(job_id2, job_output=job_output)  # no return
-    assert catalog.log_exec_stats.call_count == log_exec_stats_call_count
+    # Ensure that catalog stats were not logged for a job tha was created but failed before running
+    bad_running_timestamps = [-1, 0, None]
+    for timestamp in bad_running_timestamps:
+        log_exec_stats_call_count = catalog.log_exec_stats.call_count
+        job_id2 = "6046b539ce9c58ecf8c3e5f4"
+        subject_job = _finish_job_complete_minimal_get_test_job(
+            job_id2,
+            sched,
+            app_id,
+            gitcommit,
+            user,
+        )
+        subject_job.running = timestamp
+        subject_job.status = Status.created.value
+        sdkmr.get_job_with_permission.side_effect = [subject_job, subject_job]
+        JobsStatus(sdkmr).finish_job(subject_job, job_output=job_output)  # no return
+        assert catalog.log_exec_stats.call_count == log_exec_stats_call_count

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -132,7 +132,7 @@ def _finish_job_complete_minimal(app_id, app_module):
     catalog.log_exec_stats.assert_called_once_with(les_expected)
     mongo.update_job_resources.assert_called_once_with(job_id, resources)
 
-    # Ensure that catalog stats were not logged for a job tha was created but failed before running
+    # Ensure that catalog stats were not logged for a job that was created but failed before running
     bad_running_timestamps = [-1, 0, None]
     for timestamp in bad_running_timestamps:
         log_exec_stats_call_count = catalog.log_exec_stats.call_count

--- a/test/tests_for_sdkmr/EE2Status_test.py
+++ b/test/tests_for_sdkmr/EE2Status_test.py
@@ -136,6 +136,9 @@ def _finish_job_complete_minimal(app_id, app_module):
     bad_running_timestamps = [-1, 0, None]
     for timestamp in bad_running_timestamps:
         log_exec_stats_call_count = catalog.log_exec_stats.call_count
+        update_finished_job_with_usage_call_count = (
+            mongo.update_job_resources.call_count
+        )
         job_id2 = "6046b539ce9c58ecf8c3e5f4"
         subject_job = _finish_job_complete_minimal_get_test_job(
             job_id2,
@@ -149,3 +152,7 @@ def _finish_job_complete_minimal(app_id, app_module):
         sdkmr.get_job_with_permission.side_effect = [subject_job, subject_job]
         JobsStatus(sdkmr).finish_job(subject_job, job_output=job_output)  # no return
         assert catalog.log_exec_stats.call_count == log_exec_stats_call_count
+        assert (
+            mongo.update_job_resources.call_count
+            == update_finished_job_with_usage_call_count
+        )


### PR DESCRIPTION
EE2 is automatically being built and over-writting ee2server which is bad because there are kb-sdk bugs there.