### PR TITLE
DEVOPS-2030 Skip Cloudflare at Nersc

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 # execution_engine2 (ee2) release notes
 =========================================
 
+## 0.0.15
+- Update JobRunner and Execution Engine to substitute internal urls to go through cloudflare
+
 ## 0.0.14
 - Update clients to work with mongo7 by updating pymongo and mongoengine
 -  Fix linting issues from flake8 and black

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.0.14
+    0.0.15
 
 owners:
     [bsadkhin, tgu2, wjriehl, gaprice]

--- a/lib/execution_engine2/execution_engine2Impl.py
+++ b/lib/execution_engine2/execution_engine2Impl.py
@@ -28,9 +28,9 @@ class execution_engine2:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.0.13"
+    VERSION = "0.0.15"
     GIT_URL = "git@github.com:kbase/execution_engine2.git"
-    GIT_COMMIT_HASH = "3e9f80f38458d7b383d2e028f15213b0fcb1a77e"
+    GIT_COMMIT_HASH = "d82ec9b1c5b8fc0fc67e0ebc4b52f29d0c817835"
 
     # BEGIN_CLASS_HEADER
     MONGO_COLLECTION = "jobs"

--- a/scripts/execute_runner.sh
+++ b/scripts/execute_runner.sh
@@ -43,7 +43,7 @@ ${PYTHON_EXECUTABLE} -V "${debug_dir}/pyversion"
 
 tar -xf JobRunner.tgz && cd JobRunner && cp scripts/*.py . && chmod +x ./*.py
 
-echo "Hey here are my changes!"
+
 ${PYTHON_EXECUTABLE} ./jobrunner.py "${JOB_ID}" "${EE2_ENDPOINT}" &
 pid=$!
 

--- a/scripts/execute_runner.sh
+++ b/scripts/execute_runner.sh
@@ -3,19 +3,26 @@ set -x
 
 HOME=$(pwd)
 export HOME
+
+JOB_ID=$1
+EE2_ENDPOINT=$2
+
+# Remove 'services.' from EE2_ENDPOINT if it exists
+EE2_ENDPOINT=${EE2_ENDPOINT/services./}
+
+KBASE_ENDPOINT=$EE2_ENDPOINT
+export KBASE_ENDPOINT
+
 # Detect if we are running at NERSC and load some customization
-# Probably better ways to deal with this but this is good enough.
 if [ -e /global/homes/k/kbaserun/.local_settings ] ; then
    HOME=/global/homes/k/kbaserun
-   . $HOME/.local_settings $1 $2
+   . "$HOME/.local_settings" "$JOB_ID" "$EE2_ENDPOINT"
 fi
 
-debug_dir="debug"
-runner_logs="runner_logs"
-mkdir ${debug_dir}
-mkdir ${runner_logs}
-runner_logs=$(readlink -f runner_logs)
-debug_dir=$(readlink -f debug_dir)
+
+
+debug_dir=$(mkdir -p "$(readlink -f debug)")
+
 
 env >"${debug_dir}/envf"
 {
@@ -32,13 +39,11 @@ env >"${debug_dir}/envf"
 
 ${PYTHON_EXECUTABLE} -V "${debug_dir}/pyversion"
 
-JOB_ID=$1
-EE2_ENDPOINT=$2
-KBASE_ENDPOINT=$EE2_ENDPOINT
-export KBASE_ENDPOINT
+
 
 tar -xf JobRunner.tgz && cd JobRunner && cp scripts/*.py . && chmod +x ./*.py
 
+echo "Hey here are my changes!"
 ${PYTHON_EXECUTABLE} ./jobrunner.py "${JOB_ID}" "${EE2_ENDPOINT}" &
 pid=$!
 
@@ -49,10 +54,6 @@ trap '{ kill $pid }' SIGTERM
 wait ${pid}
 EXIT_CODE=$?
 
-# Deprecated these in favor of moving them back to ee2 container.
-#LOG_DIR="../../../logs/${JOB_ID}"
-#mkdir -p "${LOG_DIR}"
-#cp "${runner_logs}/${JOB_ID}".out "${LOG_DIR}/".
-#cp "${runner_logs}/${JOB_ID}".err "${LOG_DIR}/"
+
 kill -9 $pid2
 exit ${EXIT_CODE}


### PR DESCRIPTION
# Description of PR purpose/changes

ee2 was changed to send requests and avoid cloudflare, so send them on the internal network
The internal network is not accessible at nersc, so we have to send through cloudflare
These changes/hack modify the job runner to replace that URL when it is running at NERSC to the public URL
These changes are current deployed on production. You can run a hipmer job to prove it and see that they now run.
Corresponding changes in jobRunner are also deployed on production. https://github.com/kbase/JobRunner/pull/87

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in Github Actions and locally 
- [ ] Run a hipmer job

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/data-upload-project/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the Github Actions build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
