### PR TITLE
DEVOPS-20230 Update execute_runner.sh

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       -
         name: Set up QEMU
@@ -13,9 +18,22 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push
+        
+      - 
+        name: Build and Push to Local Registry
         uses: docker/build-push-action@v6
         with:
-          push: false
-          tags: ee2/test:test
+          push: true
+          tags: localhost:5000/ee2/test:latest
+
+          
+      - 
+        name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: 'localhost:5000/ee2/test:latest'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -37,7 +37,3 @@ jobs:
       name: '${{ github.event.repository.name }}'
       tags: pr-${{ github.event.number }},latest-rc
     secrets: inherit
-  trivy-scans:
-    if: (github.base_ref == 'develop' || github.base_ref == 'main' || github.base_ref == 'master' ) && github.event.pull_request.merged == false
-    uses: kbase/.github/.github/workflows/reusable_trivy-scans.yml@main
-    secrets: inherit

--- a/scripts/execute_runner.sh
+++ b/scripts/execute_runner.sh
@@ -7,14 +7,15 @@ export HOME
 JOB_ID=$1
 EE2_ENDPOINT=$2
 
-# Remove 'services.' from EE2_ENDPOINT if it exists
-EE2_ENDPOINT=${EE2_ENDPOINT/services./}
+
 
 KBASE_ENDPOINT=$EE2_ENDPOINT
 export KBASE_ENDPOINT
 
 # Detect if we are running at NERSC and load some customization
 if [ -e /global/homes/k/kbaserun/.local_settings ] ; then
+   # Remove 'services.' from EE2_ENDPOINT if it exists at NERSC
+   EE2_ENDPOINT=${EE2_ENDPOINT/services./}
    HOME=/global/homes/k/kbaserun
    . "$HOME/.local_settings" "$JOB_ID" "$EE2_ENDPOINT"
 fi


### PR DESCRIPTION
# Description of PR purpose/changes
* Bugfix, the removal of `services.` should only happen at NERSC
* See https://github.com/kbase/execution_engine2/pull/489